### PR TITLE
add getNotifications function and related tests for fetching GitHub i…

### DIFF
--- a/actions/copilot-dormancy/package.json
+++ b/actions/copilot-dormancy/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dormant-accounts/copilpot-dormancy-action",
-  "version": "0.1.3",
+  "version": "0.1.8",
   "description": "A GitHub Action to check for dormant accounts in a GitHub organization.",
   "keywords": [
     "github",

--- a/packages/github/package.json
+++ b/packages/github/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dormant-accounts/github",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "A GitHub integration for dormant accounts management.",
   "keywords": [],
   "license": "MIT",

--- a/packages/github/src/provider/getNotifications.test.ts
+++ b/packages/github/src/provider/getNotifications.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { getNotifications } from './getNotifications';
+
+describe('getNotifications', () => {
+  const mockIssues = Array(150)
+    .fill(0)
+    .map((_, i) => ({
+      id: i,
+      title: `Issue ${i}`,
+    }));
+
+  const mockOctokit = {
+    paginate: vi.fn().mockResolvedValue(mockIssues),
+    rest: {
+      issues: {
+        listForRepo: vi.fn(),
+      },
+    },
+  };
+
+  const mockOwner = 'testOwner';
+  const mockRepo = 'testRepo';
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should use octokit.paginate to fetch all issues', async () => {
+    const result = await getNotifications({
+      octokit: mockOctokit as any,
+      owner: mockOwner,
+      repo: mockRepo,
+    });
+
+    expect(result).toBe(mockIssues);
+    expect(mockOctokit.paginate).toHaveBeenCalledTimes(1);
+    expect(mockOctokit.paginate).toHaveBeenCalledWith(
+      mockOctokit.rest.issues.listForRepo,
+      {
+        owner: mockOwner,
+        repo: mockRepo,
+        per_page: 100,
+      },
+    );
+  });
+
+  it('should pass additional params to the GitHub API', async () => {
+    const params = {
+      state: 'open',
+      labels: 'bug,enhancement',
+      assignee: 'username',
+    };
+
+    await getNotifications({
+      octokit: mockOctokit as any,
+      owner: mockOwner,
+      repo: mockRepo,
+      params,
+    });
+
+    expect(mockOctokit.paginate).toHaveBeenCalledWith(
+      mockOctokit.rest.issues.listForRepo,
+      {
+        owner: mockOwner,
+        repo: mockRepo,
+        per_page: 100,
+        ...params,
+      },
+    );
+
+    expect(mockOctokit.paginate).toHaveBeenCalledWith(
+      mockOctokit.rest.issues.listForRepo,
+      {
+        owner: mockOwner,
+        repo: mockRepo,
+        per_page: 100,
+        ...params,
+      },
+    );
+  });
+});

--- a/packages/github/src/provider/getNotifications.ts
+++ b/packages/github/src/provider/getNotifications.ts
@@ -1,0 +1,53 @@
+import { OctokitClient } from './types';
+import { GetResponseDataTypeFromEndpointMethod } from '@octokit/types';
+
+/**
+ * Parameters for fetching issues, excluding owner and repo
+ */
+export type ListIssuesParams = Omit<
+  Parameters<OctokitClient['rest']['issues']['listForRepo']>[0],
+  'owner' | 'repo'
+>;
+
+/**
+ * Type for GitHub issue response data
+ */
+export type GitHubIssue = GetResponseDataTypeFromEndpointMethod<
+  OctokitClient['rest']['issues']['listForRepo']
+>[number];
+
+/**
+ * Interface for getNotifications parameters
+ */
+export interface GetNotificationsOptions {
+  readonly octokit: OctokitClient;
+  readonly owner: string;
+  readonly repo: string;
+  readonly params?: ListIssuesParams;
+}
+
+/**
+ * Fetch all issues from a GitHub repository with pagination using Octokit's built-in paginate method
+ * @param options - Options for fetching notifications
+ * @param {GetNotificationsOptions} options.octokit - Octokit client instance
+ * @param {string} options.owner - Repository owner
+ * @param {string} options.repo - Repository name
+ * @param {ListIssuesParams} [options.params] - Additional query parameters for the GitHub API
+ * @returns Array of GitHub issues
+ */
+export async function getNotifications({
+  octokit,
+  owner,
+  repo,
+  params = {},
+}: GetNotificationsOptions): Promise<GitHubIssue[]> {
+  const issues = await octokit.paginate(octokit.rest.issues.listForRepo, {
+    owner,
+    repo,
+    per_page: 100,
+    ...params,
+  });
+
+  console.log(`Fetched ${issues.length} total issues from ${owner}/${repo}`);
+  return issues;
+}

--- a/packages/github/src/provider/notifier.test.ts
+++ b/packages/github/src/provider/notifier.test.ts
@@ -31,6 +31,10 @@ describe('GithubIssueNotifier', () => {
   };
 
   const createMockOctokit = () => ({
+    paginate: vi.fn().mockImplementation(async (endpoint, params) => {
+      const result = await endpoint(params);
+      return result.data;
+    }),
     rest: {
       issues: {
         create: vi.fn().mockResolvedValue({


### PR DESCRIPTION
This pull request introduces a new utility function, `getNotifications`, to streamline fetching issues from a GitHub repository with pagination. It replaces direct calls to `octokit.rest.issues.listForRepo` in the `GithubIssueNotifier` class with the new utility, improving code reusability and maintainability. Additionally, test coverage has been added for the new function, and minor version updates were made to `package.json` files.