### PR TITLE
Handle copilot activity with no assignee.

### DIFF
--- a/packages/github/src/provider/copilot/fetchLatestActivityFromCopilot.ts
+++ b/packages/github/src/provider/copilot/fetchLatestActivityFromCopilot.ts
@@ -45,6 +45,14 @@ export const fetchLatestActivityFromCopilot: FetchActivityHandler<
       if (!seats?.length) continue;
 
       for (const seat of seats) {
+        if (!seat.assignee?.login) {
+          logger.warn(
+            checkType,
+            `Skipping activity record for seat with no assignee login - ${JSON.stringify(seat, undefined, 2)}`,
+          );
+          continue;
+        }
+
         const actor = (seat.assignee.login as string).toLowerCase();
 
         if (!actor) continue;


### PR DESCRIPTION
This pull request introduces a small but important improvement to the error handling in the `fetchLatestActivityFromCopilot` function. It adds a check to skip processing activity records for seats without an `assignee.login`, and logs a warning when such cases are encountered.