### PR TITLE
Add notifications-token input

### DIFF
--- a/actions/copilot-dormancy/action.yml
+++ b/actions/copilot-dormancy/action.yml
@@ -20,6 +20,9 @@ inputs:
   activity-log-token:
     description: 'GitHub token with permissions to read/write activity log repository. If not provided, the main token will be used.'
     required: false
+  notifications-token:
+    description: 'GitHub token with permissions to read/write issues in the notifications repository. If not provided, the main token will be used.'
+    required: false
   dry-run:
     description: 'Run in dry-run mode wont write activity log'
     required: false

--- a/actions/copilot-dormancy/dist/index.js
+++ b/actions/copilot-dormancy/dist/index.js
@@ -49668,10 +49668,10 @@ const formatDate = (isoString) => {
         return isoString;
     }
 };
-async function processNotifications(octokit, context, dormantAccounts, check, dormantAfter) {
+async function processNotifications(octokit, notificationsOctokit, context, dormantAccounts, check, dormantAfter) {
     const { duration: gracePeriod, body, assignUserToIssue, removeDormantAccounts, allowTeamRemoval, repo, baseLabels, dryRun, } = context;
     const notifier = new GithubIssueNotifier({
-        githubClient: octokit,
+        githubClient: notificationsOctokit,
         gracePeriod,
         repository: {
             ...repo,
@@ -49816,7 +49816,7 @@ async function run() {
         }
         if (sendNotifications) {
             lib_core.debug('Notification context: ' + safeStringify(notificationsContext));
-            notificationsResults = await processNotifications(notificationsOctokit, notificationsContext, dormantAccounts, check, duration);
+            notificationsResults = await processNotifications(octokit, notificationsOctokit, notificationsContext, dormantAccounts, check, duration);
             lib_core.setOutput('notification-results', safeStringify(notificationsResults));
             lib_core.info(`Created notifications for ${notificationsResults.notified.length} dormant accounts`);
             lib_core.info(`Closed notifications for ${notificationsResults.reactivated.length} no longer dormant accounts`);

--- a/actions/copilot-dormancy/dist/index.js
+++ b/actions/copilot-dormancy/dist/index.js
@@ -36622,6 +36622,43 @@ var copilotDormancy = (config) => {
 };
 
 //# sourceMappingURL=copilot.js.map
+;// CONCATENATED MODULE: external "fs/promises"
+const external_fs_promises_namespaceObject = __WEBPACK_EXTERNAL_createRequire(import.meta.url)("fs/promises");
+;// CONCATENATED MODULE: ./src/utils/checkBranch.ts
+
+/**
+ * Checks if a branch exists in the specified repository.
+ * @param octokit - The Octokit client instance.
+ * @param context - The context containing the owner and repo information.
+ * @param branchName - The name of the branch to check.
+ * @returns A promise that resolves to true if the branch exists, false otherwise.
+ */
+async function checkBranch(octokit, context, branchName) {
+    lib_core.debug(`checking if branch ${branchName} exists...`);
+    // Check if the activity log branch already exists
+    try {
+        await octokit.rest.repos.getBranch({
+            ...context,
+            branch: branchName,
+        });
+        // If the branch exists, return true
+        lib_core.debug(`branch '${branchName}' exists`);
+        return true;
+    }
+    catch (error) {
+        lib_core.debug(`checkBranch() error.status: ${error.status}`);
+        // Check if the error was due to the activity log branch not existing
+        if (error.status === 404) {
+            lib_core.debug(`activity log branch ${branchName} does not exist`);
+            return false;
+        }
+        else {
+            lib_core.error('an unexpected status code was returned while checking for the activity log branch');
+            throw new Error(error);
+        }
+    }
+}
+
 ;// CONCATENATED MODULE: ./src/utils/createBranch.ts
 
 /**
@@ -36649,65 +36686,6 @@ async function createBranch(octokit, context, branchName) {
     });
     lib_core.info(`📖 created activity log branch: ${branchName}`);
 }
-
-;// CONCATENATED MODULE: ./src/utils/removeCopilotLicense.ts
-
-
-/**
- * Removes a user's Copilot license by revoking directly or removing them from a Copilot team
- * based on their provisioning method.
- *
- * @param activity - Activity tracker to record removals
- * @param allowTeamRemoval - Flag indicating if users can be removed from teams that provision Copilot
- * @param lastActivityRecord - User activity record containing login info
- * @param octokit - The Octokit instance for API calls
- * @param owner - The organization owner
- * @param removeDormantAccounts - Flag indicating if accounts should actually be removed
- * @returns Promise<boolean> - True if account was removed, false otherwise
- */
-const removeCopilotLicense = async ({ lastActivityRecord, octokit, owner, removeDormantAccounts, allowTeamRemoval, activity, }) => {
-    const { data: { pending_cancellation_date, assigning_team }, } = await octokit.rest.copilot.getCopilotSeatDetailsForUser({
-        username: lastActivityRecord.login,
-        org: owner,
-    });
-    if (pending_cancellation_date) {
-        lib_core.info(`User ${lastActivityRecord.login} already has a pending cancellation date: ${pending_cancellation_date}`);
-        return true;
-    }
-    if (!removeDormantAccounts) {
-        lib_core.info(`remove-dormant-accounts setting is disabled, checking if user ${lastActivityRecord.login} has been removed from Copilot externally`);
-        return false;
-    }
-    let accountRemoved = false;
-    // When `assigning_team` is not null, the user is provisioned access for GitHub Copilot via a team
-    // and we need to remove them from that team if allowTeamRemoval is true
-    if (assigning_team) {
-        if (!allowTeamRemoval) {
-            lib_core.info(`User ${lastActivityRecord.login} is part of team "${assigning_team.name}" that provisions Copilot access, but team removal is disabled for safety`);
-            return false;
-        }
-        lib_core.info(`User ${lastActivityRecord.login} is part of a team, attempting to remove from team ${assigning_team.name}`);
-        accountRemoved = await removeCopilotUserFromTeam({
-            username: lastActivityRecord.login,
-            octokit,
-            org: owner,
-            dryRun: !removeDormantAccounts,
-        });
-    }
-    else {
-        accountRemoved = await revokeCopilotLicense({
-            logins: lastActivityRecord.login,
-            octokit,
-            org: owner,
-            dryRun: !removeDormantAccounts,
-        });
-    }
-    if (accountRemoved) {
-        lib_core.info(`Successfully removed Copilot license for ${lastActivityRecord.login}`);
-        await activity.remove(lastActivityRecord.login);
-    }
-    return accountRemoved;
-};
 
 ;// CONCATENATED MODULE: ./src/utils/getActivityLog.ts
 
@@ -36744,43 +36722,6 @@ async function getActivityLog(octokit, context, branchName, path) {
         }
         // If some other error occurred, throw it
         throw new Error(error);
-    }
-}
-
-;// CONCATENATED MODULE: external "fs/promises"
-const external_fs_promises_namespaceObject = __WEBPACK_EXTERNAL_createRequire(import.meta.url)("fs/promises");
-;// CONCATENATED MODULE: ./src/utils/checkBranch.ts
-
-/**
- * Checks if a branch exists in the specified repository.
- * @param octokit - The Octokit client instance.
- * @param context - The context containing the owner and repo information.
- * @param branchName - The name of the branch to check.
- * @returns A promise that resolves to true if the branch exists, false otherwise.
- */
-async function checkBranch(octokit, context, branchName) {
-    lib_core.debug(`checking if branch ${branchName} exists...`);
-    // Check if the activity log branch already exists
-    try {
-        await octokit.rest.repos.getBranch({
-            ...context,
-            branch: branchName,
-        });
-        // If the branch exists, return true
-        lib_core.debug(`branch '${branchName}' exists`);
-        return true;
-    }
-    catch (error) {
-        lib_core.debug(`checkBranch() error.status: ${error.status}`);
-        // Check if the error was due to the activity log branch not existing
-        if (error.status === 404) {
-            lib_core.debug(`activity log branch ${branchName} does not exist`);
-            return false;
-        }
-        else {
-            lib_core.error('an unexpected status code was returned while checking for the activity log branch');
-            throw new Error(error);
-        }
     }
 }
 
@@ -49323,40 +49264,6 @@ function getNotificationContext() {
     return parsedNotification.data;
 }
 
-;// CONCATENATED MODULE: ./src/utils/updateActivityLog.ts
-
-/**
- * Updates or creates a file in the specified repository.
- * @param octokit - The Octokit client instance.
- * @param context - The context containing the owner and repo information.
- * @param options - The options for creating or updating the file.
- * @returns The result of the file update operation.
- */
-async function updateActivityLog(octokit, context, options) {
-    try {
-        lib_core.debug(`Updating activity log file at ${options.path}...`);
-        const result = await octokit.rest.repos.createOrUpdateFileContents({
-            ...context,
-            branch: options.branch,
-            path: options.path,
-            sha: options.sha,
-            message: options.message,
-            content: options.content,
-            committer: {
-                name: 'GitHub Action',
-                email: 'action@github.com',
-            },
-        });
-        lib_core.info(`✅ Activity log updated at ${options.path}`);
-        return result.data;
-    }
-    catch (error) {
-        const errorMessage = error instanceof Error ? error.message : String(error);
-        lib_core.error(`Failed to update activity log: ${errorMessage}`);
-        throw error;
-    }
-}
-
 // EXTERNAL MODULE: ../../node_modules/.pnpm/bottleneck@2.19.5/node_modules/bottleneck/light.js
 var light = __nccwpck_require__(8144);
 ;// CONCATENATED MODULE: ../../node_modules/.pnpm/@octokit+plugin-throttling@11.0.3_@octokit+core@7.0.5/node_modules/@octokit/plugin-throttling/dist-bundle/index.js
@@ -49628,6 +49535,99 @@ function createThrottledOctokit({ token, }) {
     return octokit;
 }
 
+;// CONCATENATED MODULE: ./src/utils/removeCopilotLicense.ts
+
+
+/**
+ * Removes a user's Copilot license by revoking directly or removing them from a Copilot team
+ * based on their provisioning method.
+ *
+ * @param activity - Activity tracker to record removals
+ * @param allowTeamRemoval - Flag indicating if users can be removed from teams that provision Copilot
+ * @param lastActivityRecord - User activity record containing login info
+ * @param octokit - The Octokit instance for API calls
+ * @param owner - The organization owner
+ * @param removeDormantAccounts - Flag indicating if accounts should actually be removed
+ * @returns Promise<boolean> - True if account was removed, false otherwise
+ */
+const removeCopilotLicense = async ({ lastActivityRecord, octokit, owner, removeDormantAccounts, allowTeamRemoval, activity, }) => {
+    const { data: { pending_cancellation_date, assigning_team }, } = await octokit.rest.copilot.getCopilotSeatDetailsForUser({
+        username: lastActivityRecord.login,
+        org: owner,
+    });
+    if (pending_cancellation_date) {
+        lib_core.info(`User ${lastActivityRecord.login} already has a pending cancellation date: ${pending_cancellation_date}`);
+        return true;
+    }
+    if (!removeDormantAccounts) {
+        lib_core.info(`remove-dormant-accounts setting is disabled, checking if user ${lastActivityRecord.login} has been removed from Copilot externally`);
+        return false;
+    }
+    let accountRemoved = false;
+    // When `assigning_team` is not null, the user is provisioned access for GitHub Copilot via a team
+    // and we need to remove them from that team if allowTeamRemoval is true
+    if (assigning_team) {
+        if (!allowTeamRemoval) {
+            lib_core.info(`User ${lastActivityRecord.login} is part of team "${assigning_team.name}" that provisions Copilot access, but team removal is disabled for safety`);
+            return false;
+        }
+        lib_core.info(`User ${lastActivityRecord.login} is part of a team, attempting to remove from team ${assigning_team.name}`);
+        accountRemoved = await removeCopilotUserFromTeam({
+            username: lastActivityRecord.login,
+            octokit,
+            org: owner,
+            dryRun: !removeDormantAccounts,
+        });
+    }
+    else {
+        accountRemoved = await revokeCopilotLicense({
+            logins: lastActivityRecord.login,
+            octokit,
+            org: owner,
+            dryRun: !removeDormantAccounts,
+        });
+    }
+    if (accountRemoved) {
+        lib_core.info(`Successfully removed Copilot license for ${lastActivityRecord.login}`);
+        await activity.remove(lastActivityRecord.login);
+    }
+    return accountRemoved;
+};
+
+;// CONCATENATED MODULE: ./src/utils/updateActivityLog.ts
+
+/**
+ * Updates or creates a file in the specified repository.
+ * @param octokit - The Octokit client instance.
+ * @param context - The context containing the owner and repo information.
+ * @param options - The options for creating or updating the file.
+ * @returns The result of the file update operation.
+ */
+async function updateActivityLog(octokit, context, options) {
+    try {
+        lib_core.debug(`Updating activity log file at ${options.path}...`);
+        const result = await octokit.rest.repos.createOrUpdateFileContents({
+            ...context,
+            branch: options.branch,
+            path: options.path,
+            sha: options.sha,
+            message: options.message,
+            content: options.content,
+            committer: {
+                name: 'GitHub Action',
+                email: 'action@github.com',
+            },
+        });
+        lib_core.info(`✅ Activity log updated at ${options.path}`);
+        return result.data;
+    }
+    catch (error) {
+        const errorMessage = error instanceof Error ? error.message : String(error);
+        lib_core.error(`Failed to update activity log: ${errorMessage}`);
+        throw error;
+    }
+}
+
 ;// CONCATENATED MODULE: ./src/run.ts
 
 
@@ -49702,6 +49702,7 @@ async function run() {
         const duration = lib_core.getInput('duration');
         const token = lib_core.getInput('token');
         const activityLogToken = lib_core.getInput('activity-log-token') || token;
+        const notificationsToken = lib_core.getInput('notifications-token') || token;
         const dryRun = lib_core.getInput('dry-run') === 'true';
         const authenticatedAtBehavior = lib_core.getInput('authenticated-at-behavior');
         const checkType = 'copilot-dormancy';
@@ -49732,6 +49733,9 @@ async function run() {
         const octokit = createThrottledOctokit({ token });
         const activityLogOctokit = createThrottledOctokit({
             token: activityLogToken,
+        });
+        const notificationsOctokit = createThrottledOctokit({
+            token: notificationsToken,
         });
         const activityLog = await getActivityLog(activityLogOctokit, activityLogContext.repo, branchName, activityLogContext.path);
         if (activityLog) {
@@ -49812,7 +49816,7 @@ async function run() {
         }
         if (sendNotifications) {
             lib_core.debug('Notification context: ' + safeStringify(notificationsContext));
-            notificationsResults = await processNotifications(octokit, notificationsContext, dormantAccounts, check, duration);
+            notificationsResults = await processNotifications(notificationsOctokit, notificationsContext, dormantAccounts, check, duration);
             lib_core.setOutput('notification-results', safeStringify(notificationsResults));
             lib_core.info(`Created notifications for ${notificationsResults.notified.length} dormant accounts`);
             lib_core.info(`Closed notifications for ${notificationsResults.reactivated.length} no longer dormant accounts`);

--- a/actions/copilot-dormancy/src/notifications.test.ts
+++ b/actions/copilot-dormancy/src/notifications.test.ts
@@ -143,6 +143,7 @@ describe('Notification Processing', () => {
   it('should create notifier with correct configuration', async () => {
     await processNotifications(
       mockOctokit,
+      mockOctokit,
       notificationContext,
       mockDormantAccounts,
       createMockCheckObject(),
@@ -166,6 +167,7 @@ describe('Notification Processing', () => {
 
   it('should return results from processDormantUsers', async () => {
     const result = await processNotifications(
+      mockOctokit,
       mockOctokit,
       notificationContext,
       mockDormantAccounts,

--- a/actions/copilot-dormancy/src/run.ts
+++ b/actions/copilot-dormancy/src/run.ts
@@ -50,6 +50,7 @@ const formatDate = (isoString: string): string => {
 
 export async function processNotifications(
   octokit: OctokitClient,
+  notificationsOctokit: OctokitClient,
   context: NotificationContext,
   dormantAccounts: LastActivityRecord[],
   check: {
@@ -69,7 +70,7 @@ export async function processNotifications(
   } = context;
 
   const notifier = new GithubIssueNotifier({
-    githubClient: octokit,
+    githubClient: notificationsOctokit,
     gracePeriod,
     repository: {
       ...repo,
@@ -270,6 +271,7 @@ async function run(): Promise<void> {
       );
 
       notificationsResults = await processNotifications(
+        octokit,
         notificationsOctokit,
         notificationsContext,
         dormantAccounts,

--- a/actions/copilot-dormancy/src/run.ts
+++ b/actions/copilot-dormancy/src/run.ts
@@ -102,6 +102,7 @@ async function run(): Promise<void> {
     const duration = core.getInput('duration');
     const token = core.getInput('token');
     const activityLogToken = core.getInput('activity-log-token') || token;
+    const notificationsToken = core.getInput('notifications-token') || token;
     const dryRun = core.getInput('dry-run') === 'true';
     const authenticatedAtBehavior = core.getInput(
       'authenticated-at-behavior',
@@ -148,6 +149,9 @@ async function run(): Promise<void> {
     const octokit = createThrottledOctokit({ token });
     const activityLogOctokit = createThrottledOctokit({
       token: activityLogToken,
+    });
+    const notificationsOctokit = createThrottledOctokit({
+      token: notificationsToken,
     });
 
     const activityLog = await getActivityLog(
@@ -266,7 +270,7 @@ async function run(): Promise<void> {
       );
 
       notificationsResults = await processNotifications(
-        octokit,
+        notificationsOctokit,
         notificationsContext,
         dormantAccounts,
         check,


### PR DESCRIPTION
When notifications are being sent to a repository in a different organization (e.g. a management org in the same enterprise as the main development org), the current token input is unable to create issues in the notifications repository (for GitHub Apps).

This PR adds a notifications-token input to support this use case.