### PR TITLE
feat: migrate shared dependencies to pnpm catalog

### DIFF
--- a/actions/copilot-dormancy/dist/index.js
+++ b/actions/copilot-dormancy/dist/index.js
@@ -36622,43 +36622,6 @@ var copilotDormancy = (config) => {
 };
 
 //# sourceMappingURL=copilot.js.map
-;// CONCATENATED MODULE: external "fs/promises"
-const external_fs_promises_namespaceObject = __WEBPACK_EXTERNAL_createRequire(import.meta.url)("fs/promises");
-;// CONCATENATED MODULE: ./src/utils/checkBranch.ts
-
-/**
- * Checks if a branch exists in the specified repository.
- * @param octokit - The Octokit client instance.
- * @param context - The context containing the owner and repo information.
- * @param branchName - The name of the branch to check.
- * @returns A promise that resolves to true if the branch exists, false otherwise.
- */
-async function checkBranch(octokit, context, branchName) {
-    lib_core.debug(`checking if branch ${branchName} exists...`);
-    // Check if the activity log branch already exists
-    try {
-        await octokit.rest.repos.getBranch({
-            ...context,
-            branch: branchName,
-        });
-        // If the branch exists, return true
-        lib_core.debug(`branch '${branchName}' exists`);
-        return true;
-    }
-    catch (error) {
-        lib_core.debug(`checkBranch() error.status: ${error.status}`);
-        // Check if the error was due to the activity log branch not existing
-        if (error.status === 404) {
-            lib_core.debug(`activity log branch ${branchName} does not exist`);
-            return false;
-        }
-        else {
-            lib_core.error('an unexpected status code was returned while checking for the activity log branch');
-            throw new Error(error);
-        }
-    }
-}
-
 ;// CONCATENATED MODULE: ./src/utils/createBranch.ts
 
 /**
@@ -36686,6 +36649,65 @@ async function createBranch(octokit, context, branchName) {
     });
     lib_core.info(`📖 created activity log branch: ${branchName}`);
 }
+
+;// CONCATENATED MODULE: ./src/utils/removeCopilotLicense.ts
+
+
+/**
+ * Removes a user's Copilot license by revoking directly or removing them from a Copilot team
+ * based on their provisioning method.
+ *
+ * @param activity - Activity tracker to record removals
+ * @param allowTeamRemoval - Flag indicating if users can be removed from teams that provision Copilot
+ * @param lastActivityRecord - User activity record containing login info
+ * @param octokit - The Octokit instance for API calls
+ * @param owner - The organization owner
+ * @param removeDormantAccounts - Flag indicating if accounts should actually be removed
+ * @returns Promise<boolean> - True if account was removed, false otherwise
+ */
+const removeCopilotLicense = async ({ lastActivityRecord, octokit, owner, removeDormantAccounts, allowTeamRemoval, activity, }) => {
+    const { data: { pending_cancellation_date, assigning_team }, } = await octokit.rest.copilot.getCopilotSeatDetailsForUser({
+        username: lastActivityRecord.login,
+        org: owner,
+    });
+    if (pending_cancellation_date) {
+        lib_core.info(`User ${lastActivityRecord.login} already has a pending cancellation date: ${pending_cancellation_date}`);
+        return true;
+    }
+    if (!removeDormantAccounts) {
+        lib_core.info(`remove-dormant-accounts setting is disabled, checking if user ${lastActivityRecord.login} has been removed from Copilot externally`);
+        return false;
+    }
+    let accountRemoved = false;
+    // When `assigning_team` is not null, the user is provisioned access for GitHub Copilot via a team
+    // and we need to remove them from that team if allowTeamRemoval is true
+    if (assigning_team) {
+        if (!allowTeamRemoval) {
+            lib_core.info(`User ${lastActivityRecord.login} is part of team "${assigning_team.name}" that provisions Copilot access, but team removal is disabled for safety`);
+            return false;
+        }
+        lib_core.info(`User ${lastActivityRecord.login} is part of a team, attempting to remove from team ${assigning_team.name}`);
+        accountRemoved = await removeCopilotUserFromTeam({
+            username: lastActivityRecord.login,
+            octokit,
+            org: owner,
+            dryRun: !removeDormantAccounts,
+        });
+    }
+    else {
+        accountRemoved = await revokeCopilotLicense({
+            logins: lastActivityRecord.login,
+            octokit,
+            org: owner,
+            dryRun: !removeDormantAccounts,
+        });
+    }
+    if (accountRemoved) {
+        lib_core.info(`Successfully removed Copilot license for ${lastActivityRecord.login}`);
+        await activity.remove(lastActivityRecord.login);
+    }
+    return accountRemoved;
+};
 
 ;// CONCATENATED MODULE: ./src/utils/getActivityLog.ts
 
@@ -36722,6 +36744,43 @@ async function getActivityLog(octokit, context, branchName, path) {
         }
         // If some other error occurred, throw it
         throw new Error(error);
+    }
+}
+
+;// CONCATENATED MODULE: external "fs/promises"
+const external_fs_promises_namespaceObject = __WEBPACK_EXTERNAL_createRequire(import.meta.url)("fs/promises");
+;// CONCATENATED MODULE: ./src/utils/checkBranch.ts
+
+/**
+ * Checks if a branch exists in the specified repository.
+ * @param octokit - The Octokit client instance.
+ * @param context - The context containing the owner and repo information.
+ * @param branchName - The name of the branch to check.
+ * @returns A promise that resolves to true if the branch exists, false otherwise.
+ */
+async function checkBranch(octokit, context, branchName) {
+    lib_core.debug(`checking if branch ${branchName} exists...`);
+    // Check if the activity log branch already exists
+    try {
+        await octokit.rest.repos.getBranch({
+            ...context,
+            branch: branchName,
+        });
+        // If the branch exists, return true
+        lib_core.debug(`branch '${branchName}' exists`);
+        return true;
+    }
+    catch (error) {
+        lib_core.debug(`checkBranch() error.status: ${error.status}`);
+        // Check if the error was due to the activity log branch not existing
+        if (error.status === 404) {
+            lib_core.debug(`activity log branch ${branchName} does not exist`);
+            return false;
+        }
+        else {
+            lib_core.error('an unexpected status code was returned while checking for the activity log branch');
+            throw new Error(error);
+        }
     }
 }
 
@@ -49264,6 +49323,40 @@ function getNotificationContext() {
     return parsedNotification.data;
 }
 
+;// CONCATENATED MODULE: ./src/utils/updateActivityLog.ts
+
+/**
+ * Updates or creates a file in the specified repository.
+ * @param octokit - The Octokit client instance.
+ * @param context - The context containing the owner and repo information.
+ * @param options - The options for creating or updating the file.
+ * @returns The result of the file update operation.
+ */
+async function updateActivityLog(octokit, context, options) {
+    try {
+        lib_core.debug(`Updating activity log file at ${options.path}...`);
+        const result = await octokit.rest.repos.createOrUpdateFileContents({
+            ...context,
+            branch: options.branch,
+            path: options.path,
+            sha: options.sha,
+            message: options.message,
+            content: options.content,
+            committer: {
+                name: 'GitHub Action',
+                email: 'action@github.com',
+            },
+        });
+        lib_core.info(`✅ Activity log updated at ${options.path}`);
+        return result.data;
+    }
+    catch (error) {
+        const errorMessage = error instanceof Error ? error.message : String(error);
+        lib_core.error(`Failed to update activity log: ${errorMessage}`);
+        throw error;
+    }
+}
+
 // EXTERNAL MODULE: ../../node_modules/.pnpm/bottleneck@2.19.5/node_modules/bottleneck/light.js
 var light = __nccwpck_require__(8144);
 ;// CONCATENATED MODULE: ../../node_modules/.pnpm/@octokit+plugin-throttling@11.0.3_@octokit+core@7.0.5/node_modules/@octokit/plugin-throttling/dist-bundle/index.js
@@ -49533,99 +49626,6 @@ function createThrottledOctokit({ token, }) {
         },
     });
     return octokit;
-}
-
-;// CONCATENATED MODULE: ./src/utils/removeCopilotLicense.ts
-
-
-/**
- * Removes a user's Copilot license by revoking directly or removing them from a Copilot team
- * based on their provisioning method.
- *
- * @param activity - Activity tracker to record removals
- * @param allowTeamRemoval - Flag indicating if users can be removed from teams that provision Copilot
- * @param lastActivityRecord - User activity record containing login info
- * @param octokit - The Octokit instance for API calls
- * @param owner - The organization owner
- * @param removeDormantAccounts - Flag indicating if accounts should actually be removed
- * @returns Promise<boolean> - True if account was removed, false otherwise
- */
-const removeCopilotLicense = async ({ lastActivityRecord, octokit, owner, removeDormantAccounts, allowTeamRemoval, activity, }) => {
-    const { data: { pending_cancellation_date, assigning_team }, } = await octokit.rest.copilot.getCopilotSeatDetailsForUser({
-        username: lastActivityRecord.login,
-        org: owner,
-    });
-    if (pending_cancellation_date) {
-        lib_core.info(`User ${lastActivityRecord.login} already has a pending cancellation date: ${pending_cancellation_date}`);
-        return true;
-    }
-    if (!removeDormantAccounts) {
-        lib_core.info(`remove-dormant-accounts setting is disabled, checking if user ${lastActivityRecord.login} has been removed from Copilot externally`);
-        return false;
-    }
-    let accountRemoved = false;
-    // When `assigning_team` is not null, the user is provisioned access for GitHub Copilot via a team
-    // and we need to remove them from that team if allowTeamRemoval is true
-    if (assigning_team) {
-        if (!allowTeamRemoval) {
-            lib_core.info(`User ${lastActivityRecord.login} is part of team "${assigning_team.name}" that provisions Copilot access, but team removal is disabled for safety`);
-            return false;
-        }
-        lib_core.info(`User ${lastActivityRecord.login} is part of a team, attempting to remove from team ${assigning_team.name}`);
-        accountRemoved = await removeCopilotUserFromTeam({
-            username: lastActivityRecord.login,
-            octokit,
-            org: owner,
-            dryRun: !removeDormantAccounts,
-        });
-    }
-    else {
-        accountRemoved = await revokeCopilotLicense({
-            logins: lastActivityRecord.login,
-            octokit,
-            org: owner,
-            dryRun: !removeDormantAccounts,
-        });
-    }
-    if (accountRemoved) {
-        lib_core.info(`Successfully removed Copilot license for ${lastActivityRecord.login}`);
-        await activity.remove(lastActivityRecord.login);
-    }
-    return accountRemoved;
-};
-
-;// CONCATENATED MODULE: ./src/utils/updateActivityLog.ts
-
-/**
- * Updates or creates a file in the specified repository.
- * @param octokit - The Octokit client instance.
- * @param context - The context containing the owner and repo information.
- * @param options - The options for creating or updating the file.
- * @returns The result of the file update operation.
- */
-async function updateActivityLog(octokit, context, options) {
-    try {
-        lib_core.debug(`Updating activity log file at ${options.path}...`);
-        const result = await octokit.rest.repos.createOrUpdateFileContents({
-            ...context,
-            branch: options.branch,
-            path: options.path,
-            sha: options.sha,
-            message: options.message,
-            content: options.content,
-            committer: {
-                name: 'GitHub Action',
-                email: 'action@github.com',
-            },
-        });
-        lib_core.info(`✅ Activity log updated at ${options.path}`);
-        return result.data;
-    }
-    catch (error) {
-        const errorMessage = error instanceof Error ? error.message : String(error);
-        lib_core.error(`Failed to update activity log: ${errorMessage}`);
-        throw error;
-    }
 }
 
 ;// CONCATENATED MODULE: ./src/run.ts

--- a/actions/copilot-dormancy/package.json
+++ b/actions/copilot-dormancy/package.json
@@ -42,24 +42,24 @@
   },
   "dependencies": {
     "@actions/core": "1.11.1",
-    "@actions/github": "^6.0.1",
+    "@actions/github": "catalog:default",
     "@octokit/plugin-throttling": "11.0.3",
-    "@types/ms": "2.1.0",
-    "ms": "2.1.3",
-    "zod": "^4.1.12"
+    "@types/ms": "catalog:default",
+    "ms": "catalog:default",
+    "zod": "catalog:default"
   },
   "devDependencies": {
     "@dormant-accounts/github": "workspace:*",
-    "@types/node": "25.0.3",
+    "@types/node": "catalog:default",
     "@vercel/ncc": "0.38.4",
     "dormant-accounts": "workspace:*",
     "eslint-config-custom": "workspace:*",
-    "rimraf": "6.1.0",
+    "rimraf": "catalog:default",
     "tsconfig": "workspace:*",
-    "tsup": "8.5.0",
-    "type-fest": "5.2.0",
-    "typescript": "5.9.3",
-    "vitest": "4.0.7"
+    "tsup": "catalog:default",
+    "type-fest": "catalog:default",
+    "typescript": "catalog:default",
+    "vitest": "catalog:default"
   },
   "publishConfig": {
     "access": "public"

--- a/package.json
+++ b/package.json
@@ -35,19 +35,19 @@
   "prettier": "@vercel/style-guide/prettier",
   "devDependencies": {
     "@changesets/cli": "2.29.7",
-    "@types/node": "25.0.3",
-    "@vercel/style-guide": "5.2.0",
-    "@vitest/coverage-v8": "^4.0.7",
-    "eslint": "8.56.0",
+    "@types/node": "catalog:default",
+    "@vercel/style-guide": "catalog:default",
+    "@vitest/coverage-v8": "catalog:default",
+    "eslint": "catalog:default",
     "eslint-config-custom": "workspace:*",
     "husky": "9.1.7",
     "lint-staged": "16.2.6",
-    "prettier": "3.6.2",
+    "prettier": "catalog:default",
     "prettier-plugin-packagejson": "2.5.19",
     "publint": "0.3.15",
     "turbo": "2.6.3",
-    "typescript": "^5.9.3",
-    "vitest": "4.0.7"
+    "typescript": "catalog:default",
+    "vitest": "catalog:default"
   },
   "packageManager": "pnpm@10.19.0+sha512.c9fc7236e92adf5c8af42fd5bf1612df99c2ceb62f27047032f4720b33f8eacdde311865e91c411f2774f618d82f320808ecb51718bfa82c060c4ba7c76a32b8",
   "engines": {

--- a/packages/dormant-accounts/package.json
+++ b/packages/dormant-accounts/package.json
@@ -56,22 +56,22 @@
   "dependencies": {
     "consola": "^3.4.2",
     "lowdb": "^7.0.1",
-    "ms": "2.1.3",
-    "zod": "^4.1.12"
+    "ms": "catalog:default",
+    "zod": "catalog:default"
   },
   "devDependencies": {
     "@arethetypeswrong/cli": "0.18.2",
     "@types/consola": "^2.2.8",
-    "@types/ms": "2.1.0",
-    "@types/node": "25.0.3",
-    "@vitest/coverage-v8": "^4.0.7",
+    "@types/ms": "catalog:default",
+    "@types/node": "catalog:default",
+    "@vitest/coverage-v8": "catalog:default",
     "eslint-config-custom": "workspace:*",
     "tsconfig": "workspace:*",
-    "tsup": "8.5.0",
-    "type-fest": "5.2.0",
-    "typescript": "5.9.3",
+    "tsup": "catalog:default",
+    "type-fest": "catalog:default",
+    "typescript": "catalog:default",
     "vite": "7.3.2",
-    "vitest": "4.0.7"
+    "vitest": "catalog:default"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/github/package.json
+++ b/packages/github/package.json
@@ -45,21 +45,21 @@
     "type-check": "tsc --noEmit"
   },
   "dependencies": {
-    "@actions/github": "^6.0.1",
-    "@types/ms": "2.1.0",
-    "ms": "2.1.3"
+    "@actions/github": "catalog:default",
+    "@types/ms": "catalog:default",
+    "ms": "catalog:default"
   },
   "devDependencies": {
     "@octokit/types": "16.0.0",
-    "@types/node": "25.0.3",
+    "@types/node": "catalog:default",
     "dormant-accounts": "workspace:*",
     "eslint-config-custom": "workspace:*",
-    "rimraf": "6.1.0",
+    "rimraf": "catalog:default",
     "tsconfig": "workspace:*",
-    "tsup": "8.5.0",
-    "type-fest": "5.2.0",
-    "typescript": "5.9.3",
-    "vitest": "4.0.7"
+    "tsup": "catalog:default",
+    "type-fest": "catalog:default",
+    "typescript": "catalog:default",
+    "vitest": "catalog:default"
   },
   "publishConfig": {
     "access": "public"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,51 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+catalogs:
+  default:
+    '@actions/github':
+      specifier: ^6.0.1
+      version: 6.0.1
+    '@types/ms':
+      specifier: 2.1.0
+      version: 2.1.0
+    '@types/node':
+      specifier: 25.0.3
+      version: 25.0.3
+    '@vercel/style-guide':
+      specifier: 5.2.0
+      version: 5.2.0
+    '@vitest/coverage-v8':
+      specifier: ^4.0.7
+      version: 4.0.7
+    eslint:
+      specifier: 8.56.0
+      version: 8.56.0
+    ms:
+      specifier: 2.1.3
+      version: 2.1.3
+    prettier:
+      specifier: 3.6.2
+      version: 3.6.2
+    rimraf:
+      specifier: 6.1.0
+      version: 6.1.0
+    tsup:
+      specifier: 8.5.0
+      version: 8.5.0
+    type-fest:
+      specifier: 5.2.0
+      version: 5.2.0
+    typescript:
+      specifier: 5.9.3
+      version: 5.9.3
+    vitest:
+      specifier: 4.0.7
+      version: 4.0.7
+    zod:
+      specifier: ^4.1.12
+      version: 4.1.12
+
 importers:
 
   .:
@@ -12,16 +57,16 @@ importers:
         specifier: 2.29.7
         version: 2.29.7(@types/node@25.0.3)
       '@types/node':
-        specifier: 25.0.3
+        specifier: catalog:default
         version: 25.0.3
       '@vercel/style-guide':
-        specifier: 5.2.0
+        specifier: catalog:default
         version: 5.2.0(eslint@8.56.0)(prettier@3.6.2)(typescript@5.9.3)
       '@vitest/coverage-v8':
-        specifier: ^4.0.7
+        specifier: catalog:default
         version: 4.0.7(vitest@4.0.7(@types/node@25.0.3)(yaml@2.8.1))
       eslint:
-        specifier: 8.56.0
+        specifier: catalog:default
         version: 8.56.0
       eslint-config-custom:
         specifier: workspace:*
@@ -33,7 +78,7 @@ importers:
         specifier: 16.2.6
         version: 16.2.6
       prettier:
-        specifier: 3.6.2
+        specifier: catalog:default
         version: 3.6.2
       prettier-plugin-packagejson:
         specifier: 2.5.19
@@ -45,10 +90,10 @@ importers:
         specifier: 2.6.3
         version: 2.6.3
       typescript:
-        specifier: ^5.9.3
+        specifier: catalog:default
         version: 5.9.3
       vitest:
-        specifier: 4.0.7
+        specifier: catalog:default
         version: 4.0.7(@types/node@25.0.3)(yaml@2.8.1)
 
   actions/copilot-dormancy:
@@ -57,26 +102,26 @@ importers:
         specifier: 1.11.1
         version: 1.11.1
       '@actions/github':
-        specifier: ^6.0.1
+        specifier: catalog:default
         version: 6.0.1
       '@octokit/plugin-throttling':
         specifier: 11.0.3
         version: 11.0.3(@octokit/core@7.0.5)
       '@types/ms':
-        specifier: 2.1.0
+        specifier: catalog:default
         version: 2.1.0
       ms:
-        specifier: 2.1.3
+        specifier: catalog:default
         version: 2.1.3
       zod:
-        specifier: ^4.1.12
+        specifier: catalog:default
         version: 4.1.12
     devDependencies:
       '@dormant-accounts/github':
         specifier: workspace:*
         version: link:../../packages/github
       '@types/node':
-        specifier: 25.0.3
+        specifier: catalog:default
         version: 25.0.3
       '@vercel/ncc':
         specifier: 0.38.4
@@ -88,22 +133,22 @@ importers:
         specifier: workspace:*
         version: link:../../tooling/eslint-config-custom
       rimraf:
-        specifier: 6.1.0
+        specifier: catalog:default
         version: 6.1.0
       tsconfig:
         specifier: workspace:*
         version: link:../../tooling/tsconfig
       tsup:
-        specifier: 8.5.0
+        specifier: catalog:default
         version: 8.5.0(postcss@8.5.8)(typescript@5.9.3)(yaml@2.8.1)
       type-fest:
-        specifier: 5.2.0
+        specifier: catalog:default
         version: 5.2.0
       typescript:
-        specifier: 5.9.3
+        specifier: catalog:default
         version: 5.9.3
       vitest:
-        specifier: 4.0.7
+        specifier: catalog:default
         version: 4.0.7(@types/node@25.0.3)(yaml@2.8.1)
 
   packages/dormant-accounts:
@@ -115,10 +160,10 @@ importers:
         specifier: ^7.0.1
         version: 7.0.1
       ms:
-        specifier: 2.1.3
+        specifier: catalog:default
         version: 2.1.3
       zod:
-        specifier: ^4.1.12
+        specifier: catalog:default
         version: 4.1.12
     devDependencies:
       '@arethetypeswrong/cli':
@@ -128,13 +173,13 @@ importers:
         specifier: ^2.2.8
         version: 2.2.8
       '@types/ms':
-        specifier: 2.1.0
+        specifier: catalog:default
         version: 2.1.0
       '@types/node':
-        specifier: 25.0.3
+        specifier: catalog:default
         version: 25.0.3
       '@vitest/coverage-v8':
-        specifier: ^4.0.7
+        specifier: catalog:default
         version: 4.0.7(vitest@4.0.7(@types/node@25.0.3)(yaml@2.8.1))
       eslint-config-custom:
         specifier: workspace:*
@@ -143,38 +188,38 @@ importers:
         specifier: workspace:*
         version: link:../../tooling/tsconfig
       tsup:
-        specifier: 8.5.0
+        specifier: catalog:default
         version: 8.5.0(postcss@8.5.8)(typescript@5.9.3)(yaml@2.8.1)
       type-fest:
-        specifier: 5.2.0
+        specifier: catalog:default
         version: 5.2.0
       typescript:
-        specifier: 5.9.3
+        specifier: catalog:default
         version: 5.9.3
       vite:
         specifier: 7.3.2
         version: 7.3.2(@types/node@25.0.3)(yaml@2.8.1)
       vitest:
-        specifier: 4.0.7
+        specifier: catalog:default
         version: 4.0.7(@types/node@25.0.3)(yaml@2.8.1)
 
   packages/github:
     dependencies:
       '@actions/github':
-        specifier: ^6.0.1
+        specifier: catalog:default
         version: 6.0.1
       '@types/ms':
-        specifier: 2.1.0
+        specifier: catalog:default
         version: 2.1.0
       ms:
-        specifier: 2.1.3
+        specifier: catalog:default
         version: 2.1.3
     devDependencies:
       '@octokit/types':
         specifier: 16.0.0
         version: 16.0.0
       '@types/node':
-        specifier: 25.0.3
+        specifier: catalog:default
         version: 25.0.3
       dormant-accounts:
         specifier: workspace:*
@@ -183,52 +228,52 @@ importers:
         specifier: workspace:*
         version: link:../../tooling/eslint-config-custom
       rimraf:
-        specifier: 6.1.0
+        specifier: catalog:default
         version: 6.1.0
       tsconfig:
         specifier: workspace:*
         version: link:../../tooling/tsconfig
       tsup:
-        specifier: 8.5.0
+        specifier: catalog:default
         version: 8.5.0(postcss@8.5.8)(typescript@5.9.3)(yaml@2.8.1)
       type-fest:
-        specifier: 5.2.0
+        specifier: catalog:default
         version: 5.2.0
       typescript:
-        specifier: 5.9.3
+        specifier: catalog:default
         version: 5.9.3
       vitest:
-        specifier: 4.0.7
+        specifier: catalog:default
         version: 4.0.7(@types/node@25.0.3)(yaml@2.8.1)
 
   tooling/eslint-config-custom:
     dependencies:
       '@vercel/style-guide':
-        specifier: 5.2.0
-        version: 5.2.0(eslint@8.48.0)(prettier@3.6.2)(typescript@5.9.3)
+        specifier: catalog:default
+        version: 5.2.0(eslint@8.56.0)(prettier@3.6.2)(typescript@5.9.3)
       eslint:
-        specifier: 8.48.0
-        version: 8.48.0
+        specifier: catalog:default
+        version: 8.56.0
       eslint-config-prettier:
         specifier: ^9.1.2
-        version: 9.1.2(eslint@8.48.0)
+        version: 9.1.2(eslint@8.56.0)
       eslint-config-turbo:
         specifier: 2.6.0
-        version: 2.6.0(eslint@8.48.0)(turbo@2.6.3)
+        version: 2.6.0(eslint@8.56.0)(turbo@2.6.3)
       typescript:
-        specifier: 5.9.3
+        specifier: catalog:default
         version: 5.9.3
 
   tooling/tsconfig:
     devDependencies:
       '@vercel/style-guide':
-        specifier: 5.2.0
-        version: 5.2.0(eslint@8.48.0)(prettier@3.6.2)(typescript@5.9.3)
+        specifier: catalog:default
+        version: 5.2.0(eslint@8.56.0)(prettier@3.6.2)(typescript@5.9.3)
       eslint:
-        specifier: 8.48.0
-        version: 8.48.0
+        specifier: catalog:default
+        version: 8.56.0
       typescript:
-        specifier: 5.9.3
+        specifier: catalog:default
         version: 5.9.3
 
 packages:
@@ -305,10 +350,6 @@ packages:
     resolution: {integrity: sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/helper-validator-identifier@7.27.1':
-    resolution: {integrity: sha512-D2hP9eA+Sqx1kBZgzxZh0y1trbuU+JoDkiEwqhQ36nodYqJwyEIhPSdMNd7lOm/4io72luTPWH20Yda0xOuUow==}
-    engines: {node: '>=6.9.0'}
-
   '@babel/helper-validator-identifier@7.28.5':
     resolution: {integrity: sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==}
     engines: {node: '>=6.9.0'}
@@ -320,11 +361,6 @@ packages:
   '@babel/helpers@7.28.4':
     resolution: {integrity: sha512-HFN59MmQXGHVyYadKLVumYsA9dBFun/ldYxipEjzA4196jpLZd8UjEEBLkbEkvfYreDqJhZxYAWFPtrfhNpj4w==}
     engines: {node: '>=6.9.0'}
-
-  '@babel/parser@7.28.4':
-    resolution: {integrity: sha512-yZbBqeM6TkpP9du/I2pUZnJsRMGGvOuIrhjzC1AwHwW+6he4mni6Bp/m8ijn0iOuZuPI2BfkCoSRunpyjnrQKg==}
-    engines: {node: '>=6.0.0'}
-    hasBin: true
 
   '@babel/parser@7.28.5':
     resolution: {integrity: sha512-KKBU1VGYR7ORr3At5HAtUQ+TV3SzRCXmA/8OdDZiLDBIZxVyzXuztPjfLd3BV1PRAQGCMWWSHYhL0F8d5uHBDQ==}
@@ -341,10 +377,6 @@ packages:
 
   '@babel/traverse@7.28.4':
     resolution: {integrity: sha512-YEzuboP2qvQavAcjgQNVgsvHIDv6ZpwXvcvjmyySP2DIMuByS/6ioU5G9pYrWHM6T2YDfc7xga9iNzYOs12CFQ==}
-    engines: {node: '>=6.9.0'}
-
-  '@babel/types@7.28.4':
-    resolution: {integrity: sha512-bkFqkLhh3pMBUQQkpVgWDWq/lqzc2678eUyDlTBhRqhCHFguYYGM0Efga7tYk4TogG/3x0EEl66/OQ+WGbWB/Q==}
     engines: {node: '>=6.9.0'}
 
   '@babel/types@7.28.5':
@@ -752,10 +784,6 @@ packages:
     resolution: {integrity: sha512-269Z39MS6wVJtsoUl10L60WdkhJVdPG24Q4eZTH3nnF6lpvSShEK3wQjDX9JRWAUPvPh7COouPpU9IrqaZFvtQ==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
 
-  '@eslint/js@8.48.0':
-    resolution: {integrity: sha512-ZSjtmelB7IJfWD2Fvb7+Z+ChTIKWq6kjda95fLcQKNS5aheVHn4IkfgRQE3sIIzTcSLwLcLZUD9UBt+V7+h+Pw==}
-    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
-
   '@eslint/js@8.56.0':
     resolution: {integrity: sha512-gMsVel9D7f2HLkBma9VbtzZRehRogVRfbr++f06nL2vnCGCNlzOD+/MUov/F4p8myyAHspEhVobgjpX64q5m6A==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
@@ -953,19 +981,9 @@ packages:
     resolution: {integrity: sha512-S+9ANAvUmjutrshV4jZjaiG8XQyuJIZ8a4utWmN/vW1sgQ9IfBnPndwkmQYw53QmouOIytT874u65HEmu6H5jw==}
     engines: {node: '>=18'}
 
-  '@rollup/rollup-android-arm-eabi@4.52.5':
-    resolution: {integrity: sha512-8c1vW4ocv3UOMp9K+gToY5zL2XiiVw3k7f1ksf4yO1FlDFQ1C2u72iACFnSOceJFsWskc2WZNqeRhFRPzv+wtQ==}
-    cpu: [arm]
-    os: [android]
-
   '@rollup/rollup-android-arm-eabi@4.60.1':
     resolution: {integrity: sha512-d6FinEBLdIiK+1uACUttJKfgZREXrF0Qc2SmLII7W2AD8FfiZ9Wjd+rD/iRuf5s5dWrr1GgwXCvPqOuDquOowA==}
     cpu: [arm]
-    os: [android]
-
-  '@rollup/rollup-android-arm64@4.52.5':
-    resolution: {integrity: sha512-mQGfsIEFcu21mvqkEKKu2dYmtuSZOBMmAl5CFlPGLY94Vlcm+zWApK7F/eocsNzp8tKmbeBP8yXyAbx0XHsFNA==}
-    cpu: [arm64]
     os: [android]
 
   '@rollup/rollup-android-arm64@4.60.1':
@@ -973,19 +991,9 @@ packages:
     cpu: [arm64]
     os: [android]
 
-  '@rollup/rollup-darwin-arm64@4.52.5':
-    resolution: {integrity: sha512-takF3CR71mCAGA+v794QUZ0b6ZSrgJkArC+gUiG6LB6TQty9T0Mqh3m2ImRBOxS2IeYBo4lKWIieSvnEk2OQWA==}
-    cpu: [arm64]
-    os: [darwin]
-
   '@rollup/rollup-darwin-arm64@4.60.1':
     resolution: {integrity: sha512-mjCpF7GmkRtSJwon+Rq1N8+pI+8l7w5g9Z3vWj4T7abguC4Czwi3Yu/pFaLvA3TTeMVjnu3ctigusqWUfjZzvw==}
     cpu: [arm64]
-    os: [darwin]
-
-  '@rollup/rollup-darwin-x64@4.52.5':
-    resolution: {integrity: sha512-W901Pla8Ya95WpxDn//VF9K9u2JbocwV/v75TE0YIHNTbhqUTv9w4VuQ9MaWlNOkkEfFwkdNhXgcLqPSmHy0fA==}
-    cpu: [x64]
     os: [darwin]
 
   '@rollup/rollup-darwin-x64@4.60.1':
@@ -993,19 +1001,9 @@ packages:
     cpu: [x64]
     os: [darwin]
 
-  '@rollup/rollup-freebsd-arm64@4.52.5':
-    resolution: {integrity: sha512-QofO7i7JycsYOWxe0GFqhLmF6l1TqBswJMvICnRUjqCx8b47MTo46W8AoeQwiokAx3zVryVnxtBMcGcnX12LvA==}
-    cpu: [arm64]
-    os: [freebsd]
-
   '@rollup/rollup-freebsd-arm64@4.60.1':
     resolution: {integrity: sha512-czw90wpQq3ZsAVBlinZjAYTKduOjTywlG7fEeWKUA7oCmpA8xdTkxZZlwNJKWqILlq0wehoZcJYfBvOyhPTQ6w==}
     cpu: [arm64]
-    os: [freebsd]
-
-  '@rollup/rollup-freebsd-x64@4.52.5':
-    resolution: {integrity: sha512-jr21b/99ew8ujZubPo9skbrItHEIE50WdV86cdSoRkKtmWa+DDr6fu2c/xyRT0F/WazZpam6kk7IHBerSL7LDQ==}
-    cpu: [x64]
     os: [freebsd]
 
   '@rollup/rollup-freebsd-x64@4.60.1':
@@ -1013,18 +1011,8 @@ packages:
     cpu: [x64]
     os: [freebsd]
 
-  '@rollup/rollup-linux-arm-gnueabihf@4.52.5':
-    resolution: {integrity: sha512-PsNAbcyv9CcecAUagQefwX8fQn9LQ4nZkpDboBOttmyffnInRy8R8dSg6hxxl2Re5QhHBf6FYIDhIj5v982ATQ==}
-    cpu: [arm]
-    os: [linux]
-
   '@rollup/rollup-linux-arm-gnueabihf@4.60.1':
     resolution: {integrity: sha512-L+34Qqil+v5uC0zEubW7uByo78WOCIrBvci69E7sFASRl0X7b/MB6Cqd1lky/CtcSVTydWa2WZwFuWexjS5o6g==}
-    cpu: [arm]
-    os: [linux]
-
-  '@rollup/rollup-linux-arm-musleabihf@4.52.5':
-    resolution: {integrity: sha512-Fw4tysRutyQc/wwkmcyoqFtJhh0u31K+Q6jYjeicsGJJ7bbEq8LwPWV/w0cnzOqR2m694/Af6hpFayLJZkG2VQ==}
     cpu: [arm]
     os: [linux]
 
@@ -1033,29 +1021,14 @@ packages:
     cpu: [arm]
     os: [linux]
 
-  '@rollup/rollup-linux-arm64-gnu@4.52.5':
-    resolution: {integrity: sha512-a+3wVnAYdQClOTlyapKmyI6BLPAFYs0JM8HRpgYZQO02rMR09ZcV9LbQB+NL6sljzG38869YqThrRnfPMCDtZg==}
-    cpu: [arm64]
-    os: [linux]
-
   '@rollup/rollup-linux-arm64-gnu@4.60.1':
     resolution: {integrity: sha512-Nql7sTeAzhTAja3QXeAI48+/+GjBJ+QmAH13snn0AJSNL50JsDqotyudHyMbO2RbJkskbMbFJfIJKWA6R1LCJQ==}
-    cpu: [arm64]
-    os: [linux]
-
-  '@rollup/rollup-linux-arm64-musl@4.52.5':
-    resolution: {integrity: sha512-AvttBOMwO9Pcuuf7m9PkC1PUIKsfaAJ4AYhy944qeTJgQOqJYJ9oVl2nYgY7Rk0mkbsuOpCAYSs6wLYB2Xiw0Q==}
     cpu: [arm64]
     os: [linux]
 
   '@rollup/rollup-linux-arm64-musl@4.60.1':
     resolution: {integrity: sha512-+pUymDhd0ys9GcKZPPWlFiZ67sTWV5UU6zOJat02M1+PiuSGDziyRuI/pPue3hoUwm2uGfxdL+trT6Z9rxnlMA==}
     cpu: [arm64]
-    os: [linux]
-
-  '@rollup/rollup-linux-loong64-gnu@4.52.5':
-    resolution: {integrity: sha512-DkDk8pmXQV2wVrF6oq5tONK6UHLz/XcEVow4JTTerdeV1uqPeHxwcg7aFsfnSm9L+OO8WJsWotKM2JJPMWrQtA==}
-    cpu: [loong64]
     os: [linux]
 
   '@rollup/rollup-linux-loong64-gnu@4.60.1':
@@ -1068,11 +1041,6 @@ packages:
     cpu: [loong64]
     os: [linux]
 
-  '@rollup/rollup-linux-ppc64-gnu@4.52.5':
-    resolution: {integrity: sha512-W/b9ZN/U9+hPQVvlGwjzi+Wy4xdoH2I8EjaCkMvzpI7wJUs8sWJ03Rq96jRnHkSrcHTpQe8h5Tg3ZzUPGauvAw==}
-    cpu: [ppc64]
-    os: [linux]
-
   '@rollup/rollup-linux-ppc64-gnu@4.60.1':
     resolution: {integrity: sha512-tLQQ9aPvkBxOc/EUT6j3pyeMD6Hb8QF2BTBnCQWP/uu1lhc9AIrIjKnLYMEroIz/JvtGYgI9dF3AxHZNaEH0rw==}
     cpu: [ppc64]
@@ -1083,18 +1051,8 @@ packages:
     cpu: [ppc64]
     os: [linux]
 
-  '@rollup/rollup-linux-riscv64-gnu@4.52.5':
-    resolution: {integrity: sha512-sjQLr9BW7R/ZiXnQiWPkErNfLMkkWIoCz7YMn27HldKsADEKa5WYdobaa1hmN6slu9oWQbB6/jFpJ+P2IkVrmw==}
-    cpu: [riscv64]
-    os: [linux]
-
   '@rollup/rollup-linux-riscv64-gnu@4.60.1':
     resolution: {integrity: sha512-QKgFl+Yc1eEk6MmOBfRHYF6lTxiiiV3/z/BRrbSiW2I7AFTXoBFvdMEyglohPj//2mZS4hDOqeB0H1ACh3sBbg==}
-    cpu: [riscv64]
-    os: [linux]
-
-  '@rollup/rollup-linux-riscv64-musl@4.52.5':
-    resolution: {integrity: sha512-hq3jU/kGyjXWTvAh2awn8oHroCbrPm8JqM7RUpKjalIRWWXE01CQOf/tUNWNHjmbMHg/hmNCwc/Pz3k1T/j/Lg==}
     cpu: [riscv64]
     os: [linux]
 
@@ -1103,28 +1061,13 @@ packages:
     cpu: [riscv64]
     os: [linux]
 
-  '@rollup/rollup-linux-s390x-gnu@4.52.5':
-    resolution: {integrity: sha512-gn8kHOrku8D4NGHMK1Y7NA7INQTRdVOntt1OCYypZPRt6skGbddska44K8iocdpxHTMMNui5oH4elPH4QOLrFQ==}
-    cpu: [s390x]
-    os: [linux]
-
   '@rollup/rollup-linux-s390x-gnu@4.60.1':
     resolution: {integrity: sha512-wcuocpaOlaL1COBYiA89O6yfjlp3RwKDeTIA0hM7OpmhR1Bjo9j31G1uQVpDlTvwxGn2nQs65fBFL5UFd76FcQ==}
     cpu: [s390x]
     os: [linux]
 
-  '@rollup/rollup-linux-x64-gnu@4.52.5':
-    resolution: {integrity: sha512-hXGLYpdhiNElzN770+H2nlx+jRog8TyynpTVzdlc6bndktjKWyZyiCsuDAlpd+j+W+WNqfcyAWz9HxxIGfZm1Q==}
-    cpu: [x64]
-    os: [linux]
-
   '@rollup/rollup-linux-x64-gnu@4.60.1':
     resolution: {integrity: sha512-77PpsFQUCOiZR9+LQEFg9GClyfkNXj1MP6wRnzYs0EeWbPcHs02AXu4xuUbM1zhwn3wqaizle3AEYg5aeoohhg==}
-    cpu: [x64]
-    os: [linux]
-
-  '@rollup/rollup-linux-x64-musl@4.52.5':
-    resolution: {integrity: sha512-arCGIcuNKjBoKAXD+y7XomR9gY6Mw7HnFBv5Rw7wQRvwYLR7gBAgV7Mb2QTyjXfTveBNFAtPt46/36vV9STLNg==}
     cpu: [x64]
     os: [linux]
 
@@ -1138,29 +1081,14 @@ packages:
     cpu: [x64]
     os: [openbsd]
 
-  '@rollup/rollup-openharmony-arm64@4.52.5':
-    resolution: {integrity: sha512-QoFqB6+/9Rly/RiPjaomPLmR/13cgkIGfA40LHly9zcH1S0bN2HVFYk3a1eAyHQyjs3ZJYlXvIGtcCs5tko9Cw==}
-    cpu: [arm64]
-    os: [openharmony]
-
   '@rollup/rollup-openharmony-arm64@4.60.1':
     resolution: {integrity: sha512-4Cv23ZrONRbNtbZa37mLSueXUCtN7MXccChtKpUnQNgF010rjrjfHx3QxkS2PI7LqGT5xXyYs1a7LbzAwT0iCA==}
     cpu: [arm64]
     os: [openharmony]
 
-  '@rollup/rollup-win32-arm64-msvc@4.52.5':
-    resolution: {integrity: sha512-w0cDWVR6MlTstla1cIfOGyl8+qb93FlAVutcor14Gf5Md5ap5ySfQ7R9S/NjNaMLSFdUnKGEasmVnu3lCMqB7w==}
-    cpu: [arm64]
-    os: [win32]
-
   '@rollup/rollup-win32-arm64-msvc@4.60.1':
     resolution: {integrity: sha512-i1okWYkA4FJICtr7KpYzFpRTHgy5jdDbZiWfvny21iIKky5YExiDXP+zbXzm3dUcFpkEeYNHgQ5fuG236JPq0g==}
     cpu: [arm64]
-    os: [win32]
-
-  '@rollup/rollup-win32-ia32-msvc@4.52.5':
-    resolution: {integrity: sha512-Aufdpzp7DpOTULJCuvzqcItSGDH73pF3ko/f+ckJhxQyHtp67rHw3HMNxoIdDMUITJESNE6a8uh4Lo4SLouOUg==}
-    cpu: [ia32]
     os: [win32]
 
   '@rollup/rollup-win32-ia32-msvc@4.60.1':
@@ -1168,18 +1096,8 @@ packages:
     cpu: [ia32]
     os: [win32]
 
-  '@rollup/rollup-win32-x64-gnu@4.52.5':
-    resolution: {integrity: sha512-UGBUGPFp1vkj6p8wCRraqNhqwX/4kNQPS57BCFc8wYh0g94iVIW33wJtQAx3G7vrjjNtRaxiMUylM0ktp/TRSQ==}
-    cpu: [x64]
-    os: [win32]
-
   '@rollup/rollup-win32-x64-gnu@4.60.1':
     resolution: {integrity: sha512-k+600V9Zl1CM7eZxJgMyTUzmrmhB/0XZnF4pRypKAlAgxmedUA+1v9R+XOFv56W4SlHEzfeMtzujLJD22Uz5zg==}
-    cpu: [x64]
-    os: [win32]
-
-  '@rollup/rollup-win32-x64-msvc@4.52.5':
-    resolution: {integrity: sha512-TAcgQh2sSkykPRWLrdyy2AiceMckNf5loITqXxFI5VuQjS5tSuw3WlwdN8qv8vzjLAUTvYaH/mVjSFpbkFbpTg==}
     cpu: [x64]
     os: [win32]
 
@@ -2066,12 +1984,6 @@ packages:
     resolution: {integrity: sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
 
-  eslint@8.48.0:
-    resolution: {integrity: sha512-sb6DLeIuRXxeM1YljSe1KEx9/YYeZFQWcV8Rq9HfigmdDEugjLEVEa1ozDjL6YDjBpQHPJxJzze+alxi4T3OLg==}
-    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
-    deprecated: This version is no longer supported. Please see https://eslint.org/version-support for other options.
-    hasBin: true
-
   eslint@8.56.0:
     resolution: {integrity: sha512-Go19xM6T9puCOWntie1/P997aXxFsOi37JIHRWI514Hc6ZnaHGKY9xFhrU65RT6CcBEzZoGG1e6Nq+DT04ZtZQ==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
@@ -2914,10 +2826,6 @@ packages:
     resolution: {integrity: sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==}
     engines: {node: '>=8.6'}
 
-  picomatch@4.0.3:
-    resolution: {integrity: sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==}
-    engines: {node: '>=12'}
-
   picomatch@4.0.4:
     resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
     engines: {node: '>=12'}
@@ -2963,10 +2871,6 @@ packages:
         optional: true
       yaml:
         optional: true
-
-  postcss@8.5.6:
-    resolution: {integrity: sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==}
-    engines: {node: ^10 || ^12 || >=14}
 
   postcss@8.5.8:
     resolution: {integrity: sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==}
@@ -3093,11 +2997,6 @@ packages:
   rimraf@6.1.0:
     resolution: {integrity: sha512-DxdlA1bdNzkZK7JiNWH+BAx1x4tEJWoTofIopFo6qWUU94jYrFZ0ubY05TqH3nWPJ1nKa1JWVFDINZ3fnrle/A==}
     engines: {node: 20 || >=22}
-    hasBin: true
-
-  rollup@4.52.5:
-    resolution: {integrity: sha512-3GuObel8h7Kqdjt0gxkEzaifHTqLVW56Y/bjN7PSQtkKr0w3V/QYSdt6QWYtd7A1xUtYQigtdUfgj1RvWVtorw==}
-    engines: {node: '>=18.0.0', npm: '>=8.0.0'}
     hasBin: true
 
   rollup@4.60.1:
@@ -3548,46 +3447,6 @@ packages:
     resolution: {integrity: sha512-OljLrQ9SQdOUqTaQxqL5dEfZWrXExyyWsozYlAWFawPVNuD83igl7uJD2RTkNMbniIYgt8l81eCJGIdQF7avLQ==}
     engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
 
-  vite@7.1.12:
-    resolution: {integrity: sha512-ZWyE8YXEXqJrrSLvYgrRP7p62OziLW7xI5HYGWFzOvupfAlrLvURSzv/FyGyy0eidogEM3ujU+kUG1zuHgb6Ug==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    hasBin: true
-    peerDependencies:
-      '@types/node': ^20.19.0 || >=22.12.0
-      jiti: '>=1.21.0'
-      less: ^4.0.0
-      lightningcss: ^1.21.0
-      sass: ^1.70.0
-      sass-embedded: ^1.70.0
-      stylus: '>=0.54.8'
-      sugarss: ^5.0.0
-      terser: ^5.16.0
-      tsx: ^4.8.1
-      yaml: ^2.4.2
-    peerDependenciesMeta:
-      '@types/node':
-        optional: true
-      jiti:
-        optional: true
-      less:
-        optional: true
-      lightningcss:
-        optional: true
-      sass:
-        optional: true
-      sass-embedded:
-        optional: true
-      stylus:
-        optional: true
-      sugarss:
-        optional: true
-      terser:
-        optional: true
-      tsx:
-        optional: true
-      yaml:
-        optional: true
-
   vite@7.3.2:
     resolution: {integrity: sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -3793,7 +3652,7 @@ snapshots:
 
   '@babel/code-frame@7.27.1':
     dependencies:
-      '@babel/helper-validator-identifier': 7.27.1
+      '@babel/helper-validator-identifier': 7.28.5
       js-tokens: 4.0.0
       picocolors: 1.1.1
 
@@ -3806,10 +3665,10 @@ snapshots:
       '@babel/helper-compilation-targets': 7.27.2
       '@babel/helper-module-transforms': 7.28.3(@babel/core@7.28.4)
       '@babel/helpers': 7.28.4
-      '@babel/parser': 7.28.4
+      '@babel/parser': 7.28.5
       '@babel/template': 7.27.2
       '@babel/traverse': 7.28.4
-      '@babel/types': 7.28.4
+      '@babel/types': 7.28.5
       '@jridgewell/remapping': 2.3.5
       convert-source-map: 2.0.0
       debug: 4.4.3
@@ -3818,14 +3677,6 @@ snapshots:
       semver: 6.3.1
     transitivePeerDependencies:
       - supports-color
-
-  '@babel/eslint-parser@7.28.4(@babel/core@7.28.4)(eslint@8.48.0)':
-    dependencies:
-      '@babel/core': 7.28.4
-      '@nicolo-ribaudo/eslint-scope-5-internals': 5.1.1-v1
-      eslint: 8.48.0
-      eslint-visitor-keys: 2.1.0
-      semver: 6.3.1
 
   '@babel/eslint-parser@7.28.4(@babel/core@7.28.4)(eslint@8.56.0)':
     dependencies:
@@ -3864,14 +3715,12 @@ snapshots:
     dependencies:
       '@babel/core': 7.28.4
       '@babel/helper-module-imports': 7.27.1
-      '@babel/helper-validator-identifier': 7.27.1
+      '@babel/helper-validator-identifier': 7.28.5
       '@babel/traverse': 7.28.4
     transitivePeerDependencies:
       - supports-color
 
   '@babel/helper-string-parser@7.27.1': {}
-
-  '@babel/helper-validator-identifier@7.27.1': {}
 
   '@babel/helper-validator-identifier@7.28.5': {}
 
@@ -3880,10 +3729,6 @@ snapshots:
   '@babel/helpers@7.28.4':
     dependencies:
       '@babel/template': 7.27.2
-      '@babel/types': 7.28.5
-
-  '@babel/parser@7.28.4':
-    dependencies:
       '@babel/types': 7.28.5
 
   '@babel/parser@7.28.5':
@@ -3909,11 +3754,6 @@ snapshots:
       debug: 4.4.3
     transitivePeerDependencies:
       - supports-color
-
-  '@babel/types@7.28.4':
-    dependencies:
-      '@babel/helper-string-parser': 7.27.1
-      '@babel/helper-validator-identifier': 7.27.1
 
   '@babel/types@7.28.5':
     dependencies:
@@ -4243,11 +4083,6 @@ snapshots:
   '@esbuild/win32-x64@0.27.7':
     optional: true
 
-  '@eslint-community/eslint-utils@4.9.0(eslint@8.48.0)':
-    dependencies:
-      eslint: 8.48.0
-      eslint-visitor-keys: 3.4.3
-
   '@eslint-community/eslint-utils@4.9.0(eslint@8.56.0)':
     dependencies:
       eslint: 8.56.0
@@ -4268,8 +4103,6 @@ snapshots:
       strip-json-comments: 3.1.1
     transitivePeerDependencies:
       - supports-color
-
-  '@eslint/js@8.48.0': {}
 
   '@eslint/js@8.56.0': {}
 
@@ -4501,67 +4334,34 @@ snapshots:
 
   '@publint/pack@0.1.2': {}
 
-  '@rollup/rollup-android-arm-eabi@4.52.5':
-    optional: true
-
   '@rollup/rollup-android-arm-eabi@4.60.1':
-    optional: true
-
-  '@rollup/rollup-android-arm64@4.52.5':
     optional: true
 
   '@rollup/rollup-android-arm64@4.60.1':
     optional: true
 
-  '@rollup/rollup-darwin-arm64@4.52.5':
-    optional: true
-
   '@rollup/rollup-darwin-arm64@4.60.1':
-    optional: true
-
-  '@rollup/rollup-darwin-x64@4.52.5':
     optional: true
 
   '@rollup/rollup-darwin-x64@4.60.1':
     optional: true
 
-  '@rollup/rollup-freebsd-arm64@4.52.5':
-    optional: true
-
   '@rollup/rollup-freebsd-arm64@4.60.1':
-    optional: true
-
-  '@rollup/rollup-freebsd-x64@4.52.5':
     optional: true
 
   '@rollup/rollup-freebsd-x64@4.60.1':
     optional: true
 
-  '@rollup/rollup-linux-arm-gnueabihf@4.52.5':
-    optional: true
-
   '@rollup/rollup-linux-arm-gnueabihf@4.60.1':
-    optional: true
-
-  '@rollup/rollup-linux-arm-musleabihf@4.52.5':
     optional: true
 
   '@rollup/rollup-linux-arm-musleabihf@4.60.1':
     optional: true
 
-  '@rollup/rollup-linux-arm64-gnu@4.52.5':
-    optional: true
-
   '@rollup/rollup-linux-arm64-gnu@4.60.1':
     optional: true
 
-  '@rollup/rollup-linux-arm64-musl@4.52.5':
-    optional: true
-
   '@rollup/rollup-linux-arm64-musl@4.60.1':
-    optional: true
-
-  '@rollup/rollup-linux-loong64-gnu@4.52.5':
     optional: true
 
   '@rollup/rollup-linux-loong64-gnu@4.60.1':
@@ -4570,40 +4370,22 @@ snapshots:
   '@rollup/rollup-linux-loong64-musl@4.60.1':
     optional: true
 
-  '@rollup/rollup-linux-ppc64-gnu@4.52.5':
-    optional: true
-
   '@rollup/rollup-linux-ppc64-gnu@4.60.1':
     optional: true
 
   '@rollup/rollup-linux-ppc64-musl@4.60.1':
     optional: true
 
-  '@rollup/rollup-linux-riscv64-gnu@4.52.5':
-    optional: true
-
   '@rollup/rollup-linux-riscv64-gnu@4.60.1':
-    optional: true
-
-  '@rollup/rollup-linux-riscv64-musl@4.52.5':
     optional: true
 
   '@rollup/rollup-linux-riscv64-musl@4.60.1':
     optional: true
 
-  '@rollup/rollup-linux-s390x-gnu@4.52.5':
-    optional: true
-
   '@rollup/rollup-linux-s390x-gnu@4.60.1':
     optional: true
 
-  '@rollup/rollup-linux-x64-gnu@4.52.5':
-    optional: true
-
   '@rollup/rollup-linux-x64-gnu@4.60.1':
-    optional: true
-
-  '@rollup/rollup-linux-x64-musl@4.52.5':
     optional: true
 
   '@rollup/rollup-linux-x64-musl@4.60.1':
@@ -4612,31 +4394,16 @@ snapshots:
   '@rollup/rollup-openbsd-x64@4.60.1':
     optional: true
 
-  '@rollup/rollup-openharmony-arm64@4.52.5':
-    optional: true
-
   '@rollup/rollup-openharmony-arm64@4.60.1':
-    optional: true
-
-  '@rollup/rollup-win32-arm64-msvc@4.52.5':
     optional: true
 
   '@rollup/rollup-win32-arm64-msvc@4.60.1':
     optional: true
 
-  '@rollup/rollup-win32-ia32-msvc@4.52.5':
-    optional: true
-
   '@rollup/rollup-win32-ia32-msvc@4.60.1':
     optional: true
 
-  '@rollup/rollup-win32-x64-gnu@4.52.5':
-    optional: true
-
   '@rollup/rollup-win32-x64-gnu@4.60.1':
-    optional: true
-
-  '@rollup/rollup-win32-x64-msvc@4.52.5':
     optional: true
 
   '@rollup/rollup-win32-x64-msvc@4.60.1':
@@ -4684,26 +4451,6 @@ snapshots:
 
   '@types/semver@7.7.1': {}
 
-  '@typescript-eslint/eslint-plugin@6.21.0(@typescript-eslint/parser@6.21.0(eslint@8.48.0)(typescript@5.9.3))(eslint@8.48.0)(typescript@5.9.3)':
-    dependencies:
-      '@eslint-community/regexpp': 4.12.1
-      '@typescript-eslint/parser': 6.21.0(eslint@8.48.0)(typescript@5.9.3)
-      '@typescript-eslint/scope-manager': 6.21.0
-      '@typescript-eslint/type-utils': 6.21.0(eslint@8.48.0)(typescript@5.9.3)
-      '@typescript-eslint/utils': 6.21.0(eslint@8.48.0)(typescript@5.9.3)
-      '@typescript-eslint/visitor-keys': 6.21.0
-      debug: 4.4.3
-      eslint: 8.48.0
-      graphemer: 1.4.0
-      ignore: 5.3.2
-      natural-compare: 1.4.0
-      semver: 7.7.3
-      ts-api-utils: 1.4.3(typescript@5.9.3)
-    optionalDependencies:
-      typescript: 5.9.3
-    transitivePeerDependencies:
-      - supports-color
-
   '@typescript-eslint/eslint-plugin@6.21.0(@typescript-eslint/parser@6.21.0(eslint@8.56.0)(typescript@5.9.3))(eslint@8.56.0)(typescript@5.9.3)':
     dependencies:
       '@eslint-community/regexpp': 4.12.1
@@ -4719,19 +4466,6 @@ snapshots:
       natural-compare: 1.4.0
       semver: 7.7.3
       ts-api-utils: 1.4.3(typescript@5.9.3)
-    optionalDependencies:
-      typescript: 5.9.3
-    transitivePeerDependencies:
-      - supports-color
-
-  '@typescript-eslint/parser@6.21.0(eslint@8.48.0)(typescript@5.9.3)':
-    dependencies:
-      '@typescript-eslint/scope-manager': 6.21.0
-      '@typescript-eslint/types': 6.21.0
-      '@typescript-eslint/typescript-estree': 6.21.0(typescript@5.9.3)
-      '@typescript-eslint/visitor-keys': 6.21.0
-      debug: 4.4.3
-      eslint: 8.48.0
     optionalDependencies:
       typescript: 5.9.3
     transitivePeerDependencies:
@@ -4759,18 +4493,6 @@ snapshots:
     dependencies:
       '@typescript-eslint/types': 6.21.0
       '@typescript-eslint/visitor-keys': 6.21.0
-
-  '@typescript-eslint/type-utils@6.21.0(eslint@8.48.0)(typescript@5.9.3)':
-    dependencies:
-      '@typescript-eslint/typescript-estree': 6.21.0(typescript@5.9.3)
-      '@typescript-eslint/utils': 6.21.0(eslint@8.48.0)(typescript@5.9.3)
-      debug: 4.4.3
-      eslint: 8.48.0
-      ts-api-utils: 1.4.3(typescript@5.9.3)
-    optionalDependencies:
-      typescript: 5.9.3
-    transitivePeerDependencies:
-      - supports-color
 
   '@typescript-eslint/type-utils@6.21.0(eslint@8.56.0)(typescript@5.9.3)':
     dependencies:
@@ -4817,21 +4539,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/utils@5.62.0(eslint@8.48.0)(typescript@5.9.3)':
-    dependencies:
-      '@eslint-community/eslint-utils': 4.9.0(eslint@8.48.0)
-      '@types/json-schema': 7.0.15
-      '@types/semver': 7.7.1
-      '@typescript-eslint/scope-manager': 5.62.0
-      '@typescript-eslint/types': 5.62.0
-      '@typescript-eslint/typescript-estree': 5.62.0(typescript@5.9.3)
-      eslint: 8.48.0
-      eslint-scope: 5.1.1
-      semver: 7.7.3
-    transitivePeerDependencies:
-      - supports-color
-      - typescript
-
   '@typescript-eslint/utils@5.62.0(eslint@8.56.0)(typescript@5.9.3)':
     dependencies:
       '@eslint-community/eslint-utils': 4.9.0(eslint@8.56.0)
@@ -4842,20 +4549,6 @@ snapshots:
       '@typescript-eslint/typescript-estree': 5.62.0(typescript@5.9.3)
       eslint: 8.56.0
       eslint-scope: 5.1.1
-      semver: 7.7.3
-    transitivePeerDependencies:
-      - supports-color
-      - typescript
-
-  '@typescript-eslint/utils@6.21.0(eslint@8.48.0)(typescript@5.9.3)':
-    dependencies:
-      '@eslint-community/eslint-utils': 4.9.0(eslint@8.48.0)
-      '@types/json-schema': 7.0.15
-      '@types/semver': 7.7.1
-      '@typescript-eslint/scope-manager': 6.21.0
-      '@typescript-eslint/types': 6.21.0
-      '@typescript-eslint/typescript-estree': 6.21.0(typescript@5.9.3)
-      eslint: 8.48.0
       semver: 7.7.3
     transitivePeerDependencies:
       - supports-color
@@ -4948,37 +4641,6 @@ snapshots:
 
   '@vercel/ncc@0.38.4': {}
 
-  '@vercel/style-guide@5.2.0(eslint@8.48.0)(prettier@3.6.2)(typescript@5.9.3)':
-    dependencies:
-      '@babel/core': 7.28.4
-      '@babel/eslint-parser': 7.28.4(@babel/core@7.28.4)(eslint@8.48.0)
-      '@rushstack/eslint-patch': 1.14.0
-      '@typescript-eslint/eslint-plugin': 6.21.0(@typescript-eslint/parser@6.21.0(eslint@8.48.0)(typescript@5.9.3))(eslint@8.48.0)(typescript@5.9.3)
-      '@typescript-eslint/parser': 6.21.0(eslint@8.48.0)(typescript@5.9.3)
-      eslint-config-prettier: 9.1.2(eslint@8.48.0)
-      eslint-import-resolver-alias: 1.1.2(eslint-plugin-import@2.32.0)
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@8.48.0)
-      eslint-plugin-eslint-comments: 3.2.0(eslint@8.48.0)
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@6.21.0(eslint@8.48.0)(typescript@5.9.3))(eslint@8.48.0)
-      eslint-plugin-jest: 27.9.0(@typescript-eslint/eslint-plugin@6.21.0(@typescript-eslint/parser@6.21.0(eslint@8.48.0)(typescript@5.9.3))(eslint@8.48.0)(typescript@5.9.3))(eslint@8.48.0)(typescript@5.9.3)
-      eslint-plugin-jsx-a11y: 6.10.2(eslint@8.48.0)
-      eslint-plugin-playwright: 0.16.0(eslint-plugin-jest@27.9.0(@typescript-eslint/eslint-plugin@6.21.0(@typescript-eslint/parser@6.21.0(eslint@8.48.0)(typescript@5.9.3))(eslint@8.48.0)(typescript@5.9.3))(eslint@8.48.0)(typescript@5.9.3))(eslint@8.48.0)
-      eslint-plugin-react: 7.37.5(eslint@8.48.0)
-      eslint-plugin-react-hooks: 4.6.2(eslint@8.48.0)
-      eslint-plugin-testing-library: 6.5.0(eslint@8.48.0)(typescript@5.9.3)
-      eslint-plugin-tsdoc: 0.2.17
-      eslint-plugin-unicorn: 48.0.1(eslint@8.48.0)
-      prettier-plugin-packagejson: 2.5.19(prettier@3.6.2)
-    optionalDependencies:
-      eslint: 8.48.0
-      prettier: 3.6.2
-      typescript: 5.9.3
-    transitivePeerDependencies:
-      - eslint-import-resolver-webpack
-      - eslint-plugin-import-x
-      - jest
-      - supports-color
-
   '@vercel/style-guide@5.2.0(eslint@8.56.0)(prettier@3.6.2)(typescript@5.9.3)':
     dependencies:
       '@babel/core': 7.28.4
@@ -5036,13 +4698,13 @@ snapshots:
       chai: 6.2.1
       tinyrainbow: 3.0.3
 
-  '@vitest/mocker@4.0.7(vite@7.1.12(@types/node@25.0.3)(yaml@2.8.1))':
+  '@vitest/mocker@4.0.7(vite@7.3.2(@types/node@25.0.3)(yaml@2.8.1))':
     dependencies:
       '@vitest/spy': 4.0.7
       estree-walker: 3.0.3
       magic-string: 0.30.19
     optionalDependencies:
-      vite: 7.1.12(@types/node@25.0.3)(yaml@2.8.1)
+      vite: 7.3.2(@types/node@25.0.3)(yaml@2.8.1)
 
   '@vitest/pretty-format@4.0.7':
     dependencies:
@@ -5602,44 +5264,25 @@ snapshots:
 
   escape-string-regexp@4.0.0: {}
 
-  eslint-config-prettier@9.1.2(eslint@8.48.0):
-    dependencies:
-      eslint: 8.48.0
-
   eslint-config-prettier@9.1.2(eslint@8.56.0):
     dependencies:
       eslint: 8.56.0
 
-  eslint-config-turbo@2.6.0(eslint@8.48.0)(turbo@2.6.3):
+  eslint-config-turbo@2.6.0(eslint@8.56.0)(turbo@2.6.3):
     dependencies:
-      eslint: 8.48.0
-      eslint-plugin-turbo: 2.6.0(eslint@8.48.0)(turbo@2.6.3)
+      eslint: 8.56.0
+      eslint-plugin-turbo: 2.6.0(eslint@8.56.0)(turbo@2.6.3)
       turbo: 2.6.3
 
   eslint-import-resolver-alias@1.1.2(eslint-plugin-import@2.32.0):
     dependencies:
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@6.21.0(eslint@8.48.0)(typescript@5.9.3))(eslint@8.48.0)
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@6.21.0(eslint@8.56.0)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@8.56.0)
 
   eslint-import-resolver-node@0.3.9:
     dependencies:
       debug: 3.2.7
       is-core-module: 2.16.1
       resolve: 1.22.11
-    transitivePeerDependencies:
-      - supports-color
-
-  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@8.48.0):
-    dependencies:
-      '@nolyfill/is-core-module': 1.0.39
-      debug: 4.4.3
-      eslint: 8.48.0
-      get-tsconfig: 4.12.0
-      is-bun-module: 2.0.0
-      stable-hash: 0.0.5
-      tinyglobby: 0.2.15
-      unrs-resolver: 1.11.1
-    optionalDependencies:
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@6.21.0(eslint@8.48.0)(typescript@5.9.3))(eslint@8.48.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -5658,17 +5301,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.1(@typescript-eslint/parser@6.21.0(eslint@8.48.0)(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@8.48.0):
-    dependencies:
-      debug: 3.2.7
-    optionalDependencies:
-      '@typescript-eslint/parser': 6.21.0(eslint@8.48.0)(typescript@5.9.3)
-      eslint: 8.48.0
-      eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@8.48.0)
-    transitivePeerDependencies:
-      - supports-color
-
   eslint-module-utils@2.12.1(@typescript-eslint/parser@6.21.0(eslint@8.56.0)(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@8.56.0):
     dependencies:
       debug: 3.2.7
@@ -5680,46 +5312,11 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-eslint-comments@3.2.0(eslint@8.48.0):
-    dependencies:
-      escape-string-regexp: 1.0.5
-      eslint: 8.48.0
-      ignore: 5.3.2
-
   eslint-plugin-eslint-comments@3.2.0(eslint@8.56.0):
     dependencies:
       escape-string-regexp: 1.0.5
       eslint: 8.56.0
       ignore: 5.3.2
-
-  eslint-plugin-import@2.32.0(@typescript-eslint/parser@6.21.0(eslint@8.48.0)(typescript@5.9.3))(eslint@8.48.0):
-    dependencies:
-      '@rtsao/scc': 1.1.0
-      array-includes: 3.1.9
-      array.prototype.findlastindex: 1.2.6
-      array.prototype.flat: 1.3.3
-      array.prototype.flatmap: 1.3.3
-      debug: 3.2.7
-      doctrine: 2.1.0
-      eslint: 8.48.0
-      eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.1(@typescript-eslint/parser@6.21.0(eslint@8.48.0)(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@8.48.0)
-      hasown: 2.0.2
-      is-core-module: 2.16.1
-      is-glob: 4.0.3
-      minimatch: 3.1.2
-      object.fromentries: 2.0.8
-      object.groupby: 1.0.3
-      object.values: 1.2.1
-      semver: 6.3.1
-      string.prototype.trimend: 1.0.9
-      tsconfig-paths: 3.15.0
-    optionalDependencies:
-      '@typescript-eslint/parser': 6.21.0(eslint@8.48.0)(typescript@5.9.3)
-    transitivePeerDependencies:
-      - eslint-import-resolver-typescript
-      - eslint-import-resolver-webpack
-      - supports-color
 
   eslint-plugin-import@2.32.0(@typescript-eslint/parser@6.21.0(eslint@8.56.0)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@8.56.0):
     dependencies:
@@ -5750,16 +5347,6 @@ snapshots:
       - eslint-import-resolver-webpack
       - supports-color
 
-  eslint-plugin-jest@27.9.0(@typescript-eslint/eslint-plugin@6.21.0(@typescript-eslint/parser@6.21.0(eslint@8.48.0)(typescript@5.9.3))(eslint@8.48.0)(typescript@5.9.3))(eslint@8.48.0)(typescript@5.9.3):
-    dependencies:
-      '@typescript-eslint/utils': 5.62.0(eslint@8.48.0)(typescript@5.9.3)
-      eslint: 8.48.0
-    optionalDependencies:
-      '@typescript-eslint/eslint-plugin': 6.21.0(@typescript-eslint/parser@6.21.0(eslint@8.48.0)(typescript@5.9.3))(eslint@8.48.0)(typescript@5.9.3)
-    transitivePeerDependencies:
-      - supports-color
-      - typescript
-
   eslint-plugin-jest@27.9.0(@typescript-eslint/eslint-plugin@6.21.0(@typescript-eslint/parser@6.21.0(eslint@8.56.0)(typescript@5.9.3))(eslint@8.56.0)(typescript@5.9.3))(eslint@8.56.0)(typescript@5.9.3):
     dependencies:
       '@typescript-eslint/utils': 5.62.0(eslint@8.56.0)(typescript@5.9.3)
@@ -5769,25 +5356,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
       - typescript
-
-  eslint-plugin-jsx-a11y@6.10.2(eslint@8.48.0):
-    dependencies:
-      aria-query: 5.3.2
-      array-includes: 3.1.9
-      array.prototype.flatmap: 1.3.3
-      ast-types-flow: 0.0.8
-      axe-core: 4.11.0
-      axobject-query: 4.1.0
-      damerau-levenshtein: 1.0.8
-      emoji-regex: 9.2.2
-      eslint: 8.48.0
-      hasown: 2.0.2
-      jsx-ast-utils: 3.3.5
-      language-tags: 1.0.9
-      minimatch: 3.1.2
-      object.fromentries: 2.0.8
-      safe-regex-test: 1.1.0
-      string.prototype.includes: 2.0.1
 
   eslint-plugin-jsx-a11y@6.10.2(eslint@8.56.0):
     dependencies:
@@ -5808,47 +5376,15 @@ snapshots:
       safe-regex-test: 1.1.0
       string.prototype.includes: 2.0.1
 
-  eslint-plugin-playwright@0.16.0(eslint-plugin-jest@27.9.0(@typescript-eslint/eslint-plugin@6.21.0(@typescript-eslint/parser@6.21.0(eslint@8.48.0)(typescript@5.9.3))(eslint@8.48.0)(typescript@5.9.3))(eslint@8.48.0)(typescript@5.9.3))(eslint@8.48.0):
-    dependencies:
-      eslint: 8.48.0
-    optionalDependencies:
-      eslint-plugin-jest: 27.9.0(@typescript-eslint/eslint-plugin@6.21.0(@typescript-eslint/parser@6.21.0(eslint@8.48.0)(typescript@5.9.3))(eslint@8.48.0)(typescript@5.9.3))(eslint@8.48.0)(typescript@5.9.3)
-
   eslint-plugin-playwright@0.16.0(eslint-plugin-jest@27.9.0(@typescript-eslint/eslint-plugin@6.21.0(@typescript-eslint/parser@6.21.0(eslint@8.56.0)(typescript@5.9.3))(eslint@8.56.0)(typescript@5.9.3))(eslint@8.56.0)(typescript@5.9.3))(eslint@8.56.0):
     dependencies:
       eslint: 8.56.0
     optionalDependencies:
       eslint-plugin-jest: 27.9.0(@typescript-eslint/eslint-plugin@6.21.0(@typescript-eslint/parser@6.21.0(eslint@8.56.0)(typescript@5.9.3))(eslint@8.56.0)(typescript@5.9.3))(eslint@8.56.0)(typescript@5.9.3)
 
-  eslint-plugin-react-hooks@4.6.2(eslint@8.48.0):
-    dependencies:
-      eslint: 8.48.0
-
   eslint-plugin-react-hooks@4.6.2(eslint@8.56.0):
     dependencies:
       eslint: 8.56.0
-
-  eslint-plugin-react@7.37.5(eslint@8.48.0):
-    dependencies:
-      array-includes: 3.1.9
-      array.prototype.findlast: 1.2.5
-      array.prototype.flatmap: 1.3.3
-      array.prototype.tosorted: 1.1.4
-      doctrine: 2.1.0
-      es-iterator-helpers: 1.2.1
-      eslint: 8.48.0
-      estraverse: 5.3.0
-      hasown: 2.0.2
-      jsx-ast-utils: 3.3.5
-      minimatch: 3.1.2
-      object.entries: 1.1.9
-      object.fromentries: 2.0.8
-      object.values: 1.2.1
-      prop-types: 15.8.1
-      resolve: 2.0.0-next.5
-      semver: 6.3.1
-      string.prototype.matchall: 4.0.12
-      string.prototype.repeat: 1.0.0
 
   eslint-plugin-react@7.37.5(eslint@8.56.0):
     dependencies:
@@ -5872,14 +5408,6 @@ snapshots:
       string.prototype.matchall: 4.0.12
       string.prototype.repeat: 1.0.0
 
-  eslint-plugin-testing-library@6.5.0(eslint@8.48.0)(typescript@5.9.3):
-    dependencies:
-      '@typescript-eslint/utils': 5.62.0(eslint@8.48.0)(typescript@5.9.3)
-      eslint: 8.48.0
-    transitivePeerDependencies:
-      - supports-color
-      - typescript
-
   eslint-plugin-testing-library@6.5.0(eslint@8.56.0)(typescript@5.9.3):
     dependencies:
       '@typescript-eslint/utils': 5.62.0(eslint@8.56.0)(typescript@5.9.3)
@@ -5893,34 +5421,15 @@ snapshots:
       '@microsoft/tsdoc': 0.14.2
       '@microsoft/tsdoc-config': 0.16.2
 
-  eslint-plugin-turbo@2.6.0(eslint@8.48.0)(turbo@2.6.3):
+  eslint-plugin-turbo@2.6.0(eslint@8.56.0)(turbo@2.6.3):
     dependencies:
       dotenv: 16.0.3
-      eslint: 8.48.0
+      eslint: 8.56.0
       turbo: 2.6.3
-
-  eslint-plugin-unicorn@48.0.1(eslint@8.48.0):
-    dependencies:
-      '@babel/helper-validator-identifier': 7.27.1
-      '@eslint-community/eslint-utils': 4.9.0(eslint@8.48.0)
-      ci-info: 3.9.0
-      clean-regexp: 1.0.0
-      eslint: 8.48.0
-      esquery: 1.6.0
-      indent-string: 4.0.0
-      is-builtin-module: 3.2.1
-      jsesc: 3.1.0
-      lodash: 4.17.21
-      pluralize: 8.0.0
-      read-pkg-up: 7.0.1
-      regexp-tree: 0.1.27
-      regjsparser: 0.10.0
-      semver: 7.7.3
-      strip-indent: 3.0.0
 
   eslint-plugin-unicorn@48.0.1(eslint@8.56.0):
     dependencies:
-      '@babel/helper-validator-identifier': 7.27.1
+      '@babel/helper-validator-identifier': 7.28.5
       '@eslint-community/eslint-utils': 4.9.0(eslint@8.56.0)
       ci-info: 3.9.0
       clean-regexp: 1.0.0
@@ -5950,48 +5459,6 @@ snapshots:
   eslint-visitor-keys@2.1.0: {}
 
   eslint-visitor-keys@3.4.3: {}
-
-  eslint@8.48.0:
-    dependencies:
-      '@eslint-community/eslint-utils': 4.9.0(eslint@8.48.0)
-      '@eslint-community/regexpp': 4.12.1
-      '@eslint/eslintrc': 2.1.4
-      '@eslint/js': 8.48.0
-      '@humanwhocodes/config-array': 0.11.14
-      '@humanwhocodes/module-importer': 1.0.1
-      '@nodelib/fs.walk': 1.2.8
-      ajv: 6.12.6
-      chalk: 4.1.2
-      cross-spawn: 7.0.6
-      debug: 4.4.3
-      doctrine: 3.0.0
-      escape-string-regexp: 4.0.0
-      eslint-scope: 7.2.2
-      eslint-visitor-keys: 3.4.3
-      espree: 9.6.1
-      esquery: 1.6.0
-      esutils: 2.0.3
-      fast-deep-equal: 3.1.3
-      file-entry-cache: 6.0.1
-      find-up: 5.0.0
-      glob-parent: 6.0.2
-      globals: 13.24.0
-      graphemer: 1.4.0
-      ignore: 5.3.2
-      imurmurhash: 0.1.4
-      is-glob: 4.0.3
-      is-path-inside: 3.0.3
-      js-yaml: 4.1.0
-      json-stable-stringify-without-jsonify: 1.0.1
-      levn: 0.4.1
-      lodash.merge: 4.6.2
-      minimatch: 3.1.2
-      natural-compare: 1.4.0
-      optionator: 0.9.4
-      strip-ansi: 6.0.1
-      text-table: 0.2.0
-    transitivePeerDependencies:
-      - supports-color
 
   eslint@8.56.0:
     dependencies:
@@ -6088,10 +5555,6 @@ snapshots:
     dependencies:
       reusify: 1.1.0
 
-  fdir@6.5.0(picomatch@4.0.3):
-    optionalDependencies:
-      picomatch: 4.0.3
-
   fdir@6.5.0(picomatch@4.0.4):
     optionalDependencies:
       picomatch: 4.0.4
@@ -6120,7 +5583,7 @@ snapshots:
     dependencies:
       magic-string: 0.30.19
       mlly: 1.8.0
-      rollup: 4.52.5
+      rollup: 4.60.1
 
   flat-cache@3.2.0:
     dependencies:
@@ -6877,8 +6340,6 @@ snapshots:
 
   picomatch@2.3.2: {}
 
-  picomatch@4.0.3: {}
-
   picomatch@4.0.4: {}
 
   pidtree@0.6.0: {}
@@ -6903,12 +6364,6 @@ snapshots:
     optionalDependencies:
       postcss: 8.5.8
       yaml: 2.8.1
-
-  postcss@8.5.6:
-    dependencies:
-      nanoid: 3.3.11
-      picocolors: 1.1.1
-      source-map-js: 1.2.1
 
   postcss@8.5.8:
     dependencies:
@@ -7040,34 +6495,6 @@ snapshots:
     dependencies:
       glob: 11.0.3
       package-json-from-dist: 1.0.1
-
-  rollup@4.52.5:
-    dependencies:
-      '@types/estree': 1.0.8
-    optionalDependencies:
-      '@rollup/rollup-android-arm-eabi': 4.52.5
-      '@rollup/rollup-android-arm64': 4.52.5
-      '@rollup/rollup-darwin-arm64': 4.52.5
-      '@rollup/rollup-darwin-x64': 4.52.5
-      '@rollup/rollup-freebsd-arm64': 4.52.5
-      '@rollup/rollup-freebsd-x64': 4.52.5
-      '@rollup/rollup-linux-arm-gnueabihf': 4.52.5
-      '@rollup/rollup-linux-arm-musleabihf': 4.52.5
-      '@rollup/rollup-linux-arm64-gnu': 4.52.5
-      '@rollup/rollup-linux-arm64-musl': 4.52.5
-      '@rollup/rollup-linux-loong64-gnu': 4.52.5
-      '@rollup/rollup-linux-ppc64-gnu': 4.52.5
-      '@rollup/rollup-linux-riscv64-gnu': 4.52.5
-      '@rollup/rollup-linux-riscv64-musl': 4.52.5
-      '@rollup/rollup-linux-s390x-gnu': 4.52.5
-      '@rollup/rollup-linux-x64-gnu': 4.52.5
-      '@rollup/rollup-linux-x64-musl': 4.52.5
-      '@rollup/rollup-openharmony-arm64': 4.52.5
-      '@rollup/rollup-win32-arm64-msvc': 4.52.5
-      '@rollup/rollup-win32-ia32-msvc': 4.52.5
-      '@rollup/rollup-win32-x64-gnu': 4.52.5
-      '@rollup/rollup-win32-x64-msvc': 4.52.5
-      fsevents: 2.3.3
 
   rollup@4.60.1:
     dependencies:
@@ -7394,8 +6821,8 @@ snapshots:
 
   tinyglobby@0.2.15:
     dependencies:
-      fdir: 6.5.0(picomatch@4.0.3)
-      picomatch: 4.0.3
+      fdir: 6.5.0(picomatch@4.0.4)
+      picomatch: 4.0.4
 
   tinyrainbow@3.0.3: {}
 
@@ -7440,7 +6867,7 @@ snapshots:
       picocolors: 1.1.1
       postcss-load-config: 6.0.1(postcss@8.5.8)(yaml@2.8.1)
       resolve-from: 5.0.0
-      rollup: 4.52.5
+      rollup: 4.60.1
       source-map: 0.8.0-beta.0
       sucrase: 3.35.0
       tinyexec: 0.3.2
@@ -7604,19 +7031,6 @@ snapshots:
 
   validate-npm-package-name@5.0.1: {}
 
-  vite@7.1.12(@types/node@25.0.3)(yaml@2.8.1):
-    dependencies:
-      esbuild: 0.25.11
-      fdir: 6.5.0(picomatch@4.0.3)
-      picomatch: 4.0.3
-      postcss: 8.5.6
-      rollup: 4.52.5
-      tinyglobby: 0.2.15
-    optionalDependencies:
-      '@types/node': 25.0.3
-      fsevents: 2.3.3
-      yaml: 2.8.1
-
   vite@7.3.2(@types/node@25.0.3)(yaml@2.8.1):
     dependencies:
       esbuild: 0.27.7
@@ -7633,7 +7047,7 @@ snapshots:
   vitest@4.0.7(@types/node@25.0.3)(yaml@2.8.1):
     dependencies:
       '@vitest/expect': 4.0.7
-      '@vitest/mocker': 4.0.7(vite@7.1.12(@types/node@25.0.3)(yaml@2.8.1))
+      '@vitest/mocker': 4.0.7(vite@7.3.2(@types/node@25.0.3)(yaml@2.8.1))
       '@vitest/pretty-format': 4.0.7
       '@vitest/runner': 4.0.7
       '@vitest/snapshot': 4.0.7
@@ -7644,13 +7058,13 @@ snapshots:
       expect-type: 1.2.2
       magic-string: 0.30.19
       pathe: 2.0.3
-      picomatch: 4.0.3
+      picomatch: 4.0.4
       std-env: 3.10.0
       tinybench: 2.9.0
       tinyexec: 0.3.2
       tinyglobby: 0.2.15
       tinyrainbow: 3.0.3
-      vite: 7.1.12(@types/node@25.0.3)(yaml@2.8.1)
+      vite: 7.3.2(@types/node@25.0.3)(yaml@2.8.1)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 25.0.3

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -4,6 +4,22 @@ packages:
   - actions/*
   - examples/*
 
+catalog:
+  '@actions/github': '^6.0.1'
+  '@types/ms': '2.1.0'
+  '@types/node': '25.0.3'
+  '@vercel/style-guide': '5.2.0'
+  '@vitest/coverage-v8': '^4.0.7'
+  eslint: '8.56.0'
+  ms: '2.1.3'
+  prettier: '3.6.2'
+  rimraf: '6.1.0'
+  tsup: '8.5.0'
+  type-fest: '5.2.0'
+  typescript: '5.9.3'
+  vitest: '4.0.7'
+  zod: '^4.1.12'
+
 onlyBuiltDependencies:
   - esbuild
   - unrs-resolver

--- a/tooling/eslint-config-custom/package.json
+++ b/tooling/eslint-config-custom/package.json
@@ -5,10 +5,10 @@
   "license": "Apache-2.0",
   "main": "index.js",
   "dependencies": {
-    "@vercel/style-guide": "5.2.0",
-    "eslint": "8.48.0",
+    "@vercel/style-guide": "catalog:default",
+    "eslint": "catalog:default",
     "eslint-config-prettier": "^9.1.2",
     "eslint-config-turbo": "2.6.0",
-    "typescript": "5.9.3"
+    "typescript": "catalog:default"
   }
 }

--- a/tooling/tsconfig/package.json
+++ b/tooling/tsconfig/package.json
@@ -4,8 +4,8 @@
   "private": true,
   "license": "Apache-2.0",
   "devDependencies": {
-    "@vercel/style-guide": "5.2.0",
-    "eslint": "8.48.0",
-    "typescript": "5.9.3"
+    "@vercel/style-guide": "catalog:default",
+    "eslint": "catalog:default",
+    "typescript": "catalog:default"
   }
 }


### PR DESCRIPTION
Dependency versions are duplicated across 6 workspace `package.json` files, creating version drift risk. Two mismatches already existed: `eslint` (8.56.0 vs 8.48.0) and `typescript` (^5.9.3 vs 5.9.3). This PR centralizes shared versions using pnpm's `catalog:` protocol (supported since pnpm 9.5; this repo uses 10.19.0).

## Approach

A `catalog` section is added to `pnpm-workspace.yaml` defining 14 shared dependency versions. All `package.json` files then reference `catalog:default` instead of inline version specifiers.

**Cataloged dependencies:** `typescript`, `eslint`, `vitest`, `@vitest/coverage-v8`, `tsup`, `prettier`, `@types/node`, `@types/ms`, `type-fest`, `ms`, `@vercel/style-guide`, `rimraf`, `zod`, `@actions/github`

**Not cataloged** (single-use, package-specific): `lowdb`, `consola`, `@vercel/ncc`, `@octokit/plugin-throttling`, `@actions/core`, `vite`, etc.

## Version conflicts resolved

- `eslint`: 8.48.0 in tooling packages aligned to 8.56.0 (root version)
- `typescript`: `^5.9.3` in root pinned to `5.9.3` to match all other packages

## Validation

- `pnpm install` -- lockfile regenerated successfully
- `pnpm build` -- 3/3 packages built
- `pnpm test` -- 133 tests passed
- `pnpm lint` -- clean